### PR TITLE
feat: create @islands/feed module to generate RSS, Atom, and JSON feeds

### DIFF
--- a/docs/src/pages/config/plugins.mdx
+++ b/docs/src/pages/config/plugins.mdx
@@ -28,6 +28,10 @@
 [@islands/mdx]: https://github.com/ElMassimo/iles/tree/main/packages/mdx
 [@islands/pages]: https://github.com/ElMassimo/iles/tree/main/packages/pages
 [@islands/prism]: https://github.com/ElMassimo/iles/tree/main/packages/prism
+[@islands/feed]: https://github.com/ElMassimo/iles/tree/main/packages/feed
+
+[feed]: https://github.com/jpmonette/feed
+[feed example]: https://github.com/ElMassimo/iles/blob/main/playground/the-vue-point/src/pages/feed.vue
 
 # Modules and Plugins 🔌
 
@@ -123,6 +127,24 @@ A module to add and configure [unplugin-icons]:
     '@islands/icons',
   ],
 ```
+
+### <kbd>[@islands/feed]</kbd>
+
+A module to generate RSS and Atom feeds, powered by <kbd>[feed]</kbd>:
+
+- 📻 supports RSS, Atom, and JSON formats
+
+- 💪🏼 strongly typed
+
+- ⚡️ HMR during development to debug the result
+
+```ts
+  modules: [
+    '@islands/feed',
+  ],
+```
+
+Visit <kbd>[@islands/feed]</kbd> for usage instructions, or [see this example][feed example].
 
 ### <kbd>[@islands/prism]</kbd>
 

--- a/packages/feed/README.md
+++ b/packages/feed/README.md
@@ -54,11 +54,13 @@ path: /feed.atom
 </page>
 
 <script setup lang="ts">
+import type { FeedOptions, FeedItem } from '@islands/feed'
+
 const { site } = usePage()
 
 const url = site.url
 
-let options = {
+const options: FeedOptions = {
   title: 'The Vue Point',
   description: 'The official blog for the Vue.js project',
   id: url,
@@ -68,20 +70,19 @@ let options = {
   copyright: 'Copyright (c) 2021-present',
 }
 
-let items = $computed(() =>
-  Object.values(import.meta.globEagerDefault('./posts/**/*.mdx'))
-    .map(post => ({
-      link: `${url}${post.href}`,
-      date: new Date(post.date),
-      title: post.title,
-      description: post.description,
-      content: post,
-    }))
-)
+const posts = Object.values(import.meta.globEagerDefault('./posts/**/*.mdx'))
+
+const items = posts.map<FeedItem>(post => ({
+  link: `${url}${post.href}`,
+  date: new Date(post.date),
+  title: post.title,
+  description: post.description,
+  content: post,
+}))
 </script>
 
 <template>
-  <Feed format="atom" :options="options" :items="items"/>
+  <RenderFeed format="atom" :options="options" :items="items"/>
 </template>
 ```
 

--- a/packages/feed/README.md
+++ b/packages/feed/README.md
@@ -1,0 +1,88 @@
+<p align="center">
+  <a href="https://iles-docs.netlify.app">
+    <img src="https://github.com/ElMassimo/iles/blob/main/docs/images/banner.png"/>
+  </a>
+</p>
+
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<br/>
+<p align="center">
+  <h3><samp>@islands/feed</samp></h3>
+  <img width="2000" height="0">
+</p>
+</td>
+</tbody>
+</table>
+</p>
+
+[îles]: https://github.com/ElMassimo/iles
+[routing]: https://iles-docs.netlify.app/guide/routing
+[feed]: https://github.com/jpmonette/feed
+
+An [îles] module to generate feeds for your site:
+
+- 📻 supports RSS, Atom, and JSON feeds
+
+- ⚡️ HMR during development to debug the result
+
+- 💪🏼 strongly typed, powered by [`feed`][feed]
+
+### Installation 💿
+
+```ts
+// iles.config.ts
+import { defineConfig } from 'iles'
+
+export default defineConfig({
+  modules: [
+    '@islands/feed',
+  ],
+})
+```
+
+### Usage 🚀
+
+To generate a feed, create a Vue SFC and specify a [`path`][routing] with the appropriate
+extension:
+
+```
+<page>
+path: /feed.atom
+</page>
+
+<script setup lang="ts">
+const { site } = usePage()
+
+const url = site.url
+
+let options = {
+  title: 'The Vue Point',
+  description: 'The official blog for the Vue.js project',
+  id: url,
+  link: url,
+  language: 'en',
+  image: 'https://vuejs.org/images/logo.png',
+  copyright: 'Copyright (c) 2021-present',
+}
+
+let items = $computed(() =>
+  Object.values(import.meta.globEagerDefault('./posts/**/*.mdx'))
+    .map(post => ({
+      link: `${url}${post.href}`,
+      date: new Date(post.date),
+      title: post.title,
+      description: post.description,
+      content: post,
+    }))
+)
+</script>
+
+<template>
+  <Feed format="atom" :options="options" :items="items"/>
+</template>
+```
+
+Check the [`feed` documentation][feed] for more information.

--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "npm run build -- --watch",
-    "build": "tsup src/feed.ts src/render-feed.ts",
+    "build": "rimraf -rf dist && tsup src/types.ts src/feed.ts src/render-feed.ts",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@islands/feed",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "npm run build -- --watch",
+    "build": "tsup src/feed.ts src/render-feed.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "types": "dist/feed.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/feed.js",
+      "require": "./src/feed.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "funding": "https://github.com/sponsors/ElMassimo",
+  "author": "Máximo Mussini <maximomussini@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ElMassimo/iles"
+  },
+  "homepage": "https://github.com/ElMassimo/iles",
+  "bugs": "https://github.com/ElMassimo/iles/issues",
+  "devDependencies": {
+    "iles": "workspace:*",
+    "vue": "^3.2"
+  },
+  "peerDependencies": {
+    "iles": "workspace:^0.7",
+    "vue": "^3.2"
+  },
+  "dependencies": {
+    "feed": "^4.2"
+  }
+}

--- a/packages/feed/src/feed.cjs
+++ b/packages/feed/src/feed.cjs
@@ -1,0 +1,5 @@
+module.exports = (...args) => new Promise((resolve, reject) => {
+  import('../dist/feed.js')
+    .then(m => resolve(m.default(...args)))
+    .catch(reject)
+})

--- a/packages/feed/src/feed.ts
+++ b/packages/feed/src/feed.ts
@@ -1,0 +1,22 @@
+import type { IlesModule } from 'iles'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * An iles module that provides a component to generate RSS, Atom, and JSON feeds.
+ */
+export default function IlesFeed (): IlesModule {
+  return {
+    name: '@islands/feed',
+    components: {
+      resolvers: [
+        (name) => {
+          if (name === 'RenderFeed')
+            return { importName: 'RenderFeed', path: join(__dirname, 'render-feed') }
+        }
+      ],
+    },
+  }
+}

--- a/packages/feed/src/feed.ts
+++ b/packages/feed/src/feed.ts
@@ -2,6 +2,8 @@ import type { IlesModule } from 'iles'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
+export * from './types'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 /**

--- a/packages/feed/src/render-feed.ts
+++ b/packages/feed/src/render-feed.ts
@@ -1,15 +1,14 @@
-import type { FeedOptions, Item, Author, Extension } from 'feed'
 import { createStaticVNode, defineComponent, PropType, defineAsyncComponent, h } from 'vue'
 import { useVueRenderer } from 'iles'
+import type { FeedOptions, FeedFormat, FeedItem, Author, Extension, ResolvedItem } from './types'
 
-type AsyncContent = Parameters<ReturnType<typeof useVueRenderer>>[0]
-
-interface AsyncItem extends Omit<Item, 'description' | 'content'> {
-  description?: string | AsyncContent
-  content?: string | AsyncContent
+const formats: Record<string, FeedFormat> = {
+  atom: 'atom1',
+  rss: 'rss2',
+  json: 'json1',
 }
 
-interface FeedProps<T = AsyncItem> {
+export interface FeedProps<T = FeedItem> {
   format?: 'atom' | 'rss' | 'json'
   options: FeedOptions
   items?: T[]
@@ -18,20 +17,12 @@ interface FeedProps<T = AsyncItem> {
   extensions?: Extension[]
 }
 
-type FeedFormat = 'atom1' | 'rss2' | 'json1'
-
-const formats: Record<string, FeedFormat> = {
-  atom: 'atom1',
-  rss: 'rss2',
-  json: 'json1',
-}
-
 export const RenderFeed = defineComponent({
   name: 'RenderFeed',
   props: {
     format: { type: String as PropType<'atom' | 'rss' | 'json'>, required: true },
     options: { type: Object as PropType<FeedOptions>, required: true },
-    items: { type: Array as PropType<AsyncItem[]>, default: undefined },
+    items: { type: Array as PropType<FeedItem[]>, default: undefined },
     categories: { type: Array as PropType<string[]>, default: undefined },
     contributors: { type: Array as PropType<Author[]>, default: undefined },
     extensions: { type: Array as PropType<Extension[]>, default: undefined },
@@ -59,7 +50,7 @@ export const RenderFeed = defineComponent({
   },
 })
 
-async function renderFeed (format: FeedFormat, { options, ...props }: FeedProps<Item>) {
+async function renderFeed (format: FeedFormat, { options, ...props }: FeedProps<ResolvedItem>) {
   const { Feed } = await import('feed')
   const feed = new Feed(options)
 

--- a/packages/feed/src/render-feed.ts
+++ b/packages/feed/src/render-feed.ts
@@ -1,0 +1,90 @@
+import type { FeedOptions, Item, Author, Extension } from 'feed'
+import { createStaticVNode, defineComponent, PropType, defineAsyncComponent, h } from 'vue'
+import { useVueRenderer } from 'iles'
+
+type AsyncContent = Parameters<ReturnType<typeof useVueRenderer>>[0]
+
+interface AsyncItem extends Omit<Item, 'description' | 'content'> {
+  description?: string | AsyncContent
+  content?: string | AsyncContent
+}
+
+interface FeedProps<T = AsyncItem> {
+  format?: 'atom' | 'rss' | 'json'
+  options: FeedOptions
+  items?: T[]
+  categories?: string[]
+  contributors?: Author[]
+  extensions?: Extension[]
+}
+
+type FeedFormat = 'atom1' | 'rss2' | 'json1'
+
+const formats: Record<string, FeedFormat> = {
+  atom: 'atom1',
+  rss: 'rss2',
+  json: 'json1',
+}
+
+const isSSR = typeof window === undefined
+
+export const RenderFeed = defineComponent({
+  name: 'RenderFeed',
+  props: {
+    format: { type: String as PropType<'atom' | 'rss' | 'json'>, required: true },
+    options: { type: Object as PropType<FeedOptions>, required: true },
+    items: { type: Array as PropType<AsyncItem[]>, default: undefined },
+    categories: { type: Array as PropType<string[]>, default: undefined },
+    contributors: { type: Array as PropType<Author[]>, default: undefined },
+    extensions: { type: Array as PropType<Extension[]>, default: undefined },
+  },
+  setup (props) {
+    const renderContent = useVueRenderer()
+    const renderComponent = isSSR ? renderFeed : renderRaw
+
+    return () => {
+      const format = formats[props.format || 'atom']
+      if (!format) throw new Error(`@islands/feed: Unknown format '${props.format}'`)
+
+      let itemPromises = (props.items || []).map(({ description, content, ...item }) => ({
+        description: skipRender(description) ? description : renderContent(description),
+        content: skipRender(content) ? content :  renderContent(content),
+        ...item,
+      }))
+
+      console.log('itemPromises', itemPromises.map(i => i.content))
+
+      return h(defineAsyncComponent(async () => {
+        const items = await Promise.all(itemPromises.map(async (item) => ({
+          ...item,
+          description: await item.description,
+          content: await item.content,
+        })))
+
+        return await renderComponent(format, { ...props, items })
+      }))
+    }
+  },
+})
+
+async function renderFeed (format: FeedFormat, { options, ...props }: FeedProps<Item>) {
+  const { Feed } = await import('feed')
+  const feed = new Feed(options)
+
+  props.items?.forEach(feed.addItem)
+  props.categories?.forEach(feed.addCategory)
+  props.contributors?.forEach(feed.addContributor)
+  props.extensions?.forEach(feed.addExtension)
+
+  return createStaticVNode(feed[format](), 1)
+}
+
+function renderRaw (_format: FeedFormat, { options, ...props }: FeedProps) {
+  const json = JSON.stringify({ ...options, ...props }, null, 2)
+  const style = 'word-break: break-word; white-space: pre-wrap;'
+  return h('pre', { style }, h('code', null, json))
+}
+
+function skipRender (content: any): content is string | undefined {
+  return content === undefined || typeof content === 'string'
+}

--- a/packages/feed/src/types.ts
+++ b/packages/feed/src/types.ts
@@ -1,0 +1,13 @@
+import type { FeedOptions, Item as ResolvedItem, Author, Extension } from 'feed'
+import type { useVueRenderer } from 'iles'
+
+export type AsyncContent = string | Parameters<ReturnType<typeof useVueRenderer>>[0]
+
+export { FeedOptions, ResolvedItem, Author, Extension }
+
+export interface FeedItem extends Omit<ResolvedItem, 'description' | 'content'> {
+  description?: AsyncContent
+  content?: AsyncContent
+}
+
+export type FeedFormat = 'atom1' | 'rss2' | 'json1'

--- a/packages/feed/tsup.config.ts
+++ b/packages/feed/tsup.config.ts
@@ -1,0 +1,7 @@
+import type { Options } from 'tsup'
+export const tsup: Options = {
+  dts: true,
+  target: 'node14',
+  splitting: false,
+  format: ['esm'],
+}

--- a/packages/iles/package.json
+++ b/packages/iles/package.json
@@ -71,6 +71,7 @@
     "@islands/headings": "workspace:^0.1.0",
     "@islands/icons": "workspace:^0.1.0",
     "@islands/prism": "workspace:^0.1.0",
+    "@islands/feed": "workspace:^0.1.0",
     "@preact/preset-vite": "^2",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
     "@types/connect": "^3.4.35",

--- a/packages/iles/src/client/app/composables/vueRenderer.ts
+++ b/packages/iles/src/client/app/composables/vueRenderer.ts
@@ -3,7 +3,7 @@ import { getCurrentInstance, createApp, createSSRApp, ssrContextKey, withCtx } f
 
 const newApp = import.meta.env.SSR ? createApp : createSSRApp
 
-type Nodes = undefined | VNode | VNode[]
+type Nodes = undefined | VNode<any, any, any> | VNode<any, any, any>[]
 
 export type VNodeRenderer = (vNodes: Nodes | (() => Nodes | Promise<Nodes>)) => Promise<string>
 

--- a/packages/iles/src/client/app/composables/vueRenderer.ts
+++ b/packages/iles/src/client/app/composables/vueRenderer.ts
@@ -1,7 +1,8 @@
 import type { AppContext, VNode } from 'vue'
 import { getCurrentInstance, createApp, createSSRApp, ssrContextKey, withCtx } from 'vue'
 
-const newApp = import.meta.env.SSR ? createApp : createSSRApp
+const isSSR = typeof window === undefined
+const newApp = isSSR ? createApp : createSSRApp
 
 type Nodes = undefined | VNode | VNode[]
 
@@ -15,6 +16,7 @@ export function useVueRenderer (): VNodeRenderer {
     const { app: _, provides: appProvides, ...appContext }
       = getCurrentInstance()?.appContext || {} as AppContext
     // @ts-ignore
+    console.log({ currentInstance: getCurrentInstance() })
     const { [ssrContextKey]: ssrContext, ...provides } = appProvides
 
     // Initialize a new application that returns the specified nodes.

--- a/packages/iles/src/client/app/composables/vueRenderer.ts
+++ b/packages/iles/src/client/app/composables/vueRenderer.ts
@@ -1,8 +1,7 @@
 import type { AppContext, VNode } from 'vue'
 import { getCurrentInstance, createApp, createSSRApp, ssrContextKey, withCtx } from 'vue'
 
-const isSSR = typeof window === undefined
-const newApp = isSSR ? createApp : createSSRApp
+const newApp = import.meta.env.SSR ? createApp : createSSRApp
 
 type Nodes = undefined | VNode | VNode[]
 
@@ -16,7 +15,6 @@ export function useVueRenderer (): VNodeRenderer {
     const { app: _, provides: appProvides, ...appContext }
       = getCurrentInstance()?.appContext || {} as AppContext
     // @ts-ignore
-    console.log({ currentInstance: getCurrentInstance() })
     const { [ssrContextKey]: ssrContext, ...provides } = appProvides
 
     // Initialize a new application that returns the specified nodes.

--- a/packages/iles/src/node/index.ts
+++ b/packages/iles/src/node/index.ts
@@ -4,8 +4,6 @@ export { build } from './build/build'
 export { resolveConfig } from './config'
 import { UserConfig } from '../../types/shared'
 
-export { useVueRenderer } from '../client/app/composables/vueRenderer'
-
 export function defineConfig (config: UserConfig) {
   return config
 }

--- a/packages/iles/src/node/index.ts
+++ b/packages/iles/src/node/index.ts
@@ -4,6 +4,8 @@ export { build } from './build/build'
 export { resolveConfig } from './config'
 import { UserConfig } from '../../types/shared'
 
+export { useVueRenderer } from '../client/app/composables/vueRenderer'
+
 export function defineConfig (config: UserConfig) {
   return config
 }

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "npm -C hydration run 'build' && npm -C prerender run 'build' && npm -C pages run 'build' && npm -C mdx run 'build' && npm -C headings run 'build' && npm -C prism run 'build' && npm -C feed run 'build' && npm -C iles run 'build' && npm -C icons run 'build'",
+    "build": "npm -C hydration run 'build' && npm -C prerender run 'build' && npm -C pages run 'build' && npm -C mdx run 'build' && npm -C iles run 'build' && npm -C headings run 'build' && npm -C prism run 'build' && npm -C feed run 'build' && npm -C icons run 'build'",
     "build-fast": "pnpm -r --parallel --filter . --filter !iles run build -- --no-dts && npm -C iles run build-fast",
     "dev": "pnpm -r --parallel --filter . run dev"
   }

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "npm -C hydration run 'build' && npm -C prerender run 'build' && npm -C pages run 'build' && npm -C mdx run 'build' && npm -C headings run 'build' && npm -C prism run 'build' && npm -C icons run 'build' && npm -C iles run 'build'",
+    "build": "npm -C hydration run 'build' && npm -C prerender run 'build' && npm -C pages run 'build' && npm -C mdx run 'build' && npm -C headings run 'build' && npm -C prism run 'build' && npm -C feed run 'build' && npm -C iles run 'build' && npm -C icons run 'build'",
     "build-fast": "pnpm -r --parallel --filter . --filter !iles run build -- --no-dts && npm -C iles run build-fast",
     "dev": "pnpm -r --parallel --filter . run dev"
   }

--- a/playground/the-vue-point/components.d.ts
+++ b/playground/the-vue-point/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     Island: typeof import('iles')['Island']
     NavBarLinks: typeof import('./src/components/NavBarLinks.svelte')['default']
     PostDate: typeof import('./src/components/PostDate.vue')['default']
+    RenderFeed: typeof import('./../../packages/feed/dist/render-feed')['RenderFeed']
   }
 }
 

--- a/playground/the-vue-point/iles.config.ts
+++ b/playground/the-vue-point/iles.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   modules: [
     '@islands/icons',
     '@islands/prism',
-    '@islands/feed'
+    '@islands/feed',
   ],
   // Example: Configure all posts to use a different layout without having to
   // add `layout: 'post'` in every file.

--- a/playground/the-vue-point/iles.config.ts
+++ b/playground/the-vue-point/iles.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   modules: [
     '@islands/icons',
     '@islands/prism',
+    '@islands/feed'
   ],
   // Example: Configure all posts to use a different layout without having to
   // add `layout: 'post'` in every file.

--- a/playground/the-vue-point/package.json
+++ b/playground/the-vue-point/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "@iconify-json/carbon": "^1.0.7",
+    "@islands/feed": "workspace:*",
     "@islands/icons": "workspace:*",
     "@islands/prism": "workspace:*",
-    "feed": "^4.2.1",
     "iles": "workspace:*",
     "vite-plugin-windicss": "^1.5.1"
   }

--- a/playground/the-vue-point/src/pages/feed.vue
+++ b/playground/the-vue-point/src/pages/feed.vue
@@ -3,12 +3,11 @@ path: /feed.rss
 </page>
 
 <script setup lang="ts">
-import { plainText, useVueRenderer } from 'iles'
-import { defineAsyncComponent } from 'vue'
-import { getPosts, Post } from '~/logic/posts'
+import { getPosts } from '~/logic/posts'
 
 const { site } = usePage()
 const url = site.url
+
 const options = {
   title: 'The Vue Point',
   description: 'The official blog for the Vue.js project',
@@ -21,46 +20,22 @@ const options = {
     'Copyright (c) 2021-present, Yuxi (Evan) You and blog contributors',
 }
 
-let posts = $(getPosts())
-const renderVNodes = useVueRenderer()
-
-let rssPosts = $computed(() => posts.map(post => toRSS(post)))
-
-async function renderFeedItems () {
-  return await Promise.all(rssPosts.map(async post => await post))
-}
-
-async function renderRSS () {
-  const items = await renderFeedItems()
-  if (!import.meta.env.SSR) return JSON.stringify({ ...options, items }, null, 2)
-  const { Feed } = require('feed')
-  const feed = new Feed(options)
-  items.forEach(item => feed.addItem(item))
-  return feed.rss2()
-}
-
-async function toRSS (post: Post) {
-  return {
-    title: post.title,
-    id: `${url}${post.href}`,
-    link: `${url}${post.href}`,
-    description: await renderVNodes(post.excerpt),
-    content: await renderVNodes(post.render),
-    author: [
-      {
-        name: post.author,
-        link: post.twitter
-          ? `https://twitter.com/${post.twitter}`
-          : undefined,
-      },
-    ],
-    date: new Date(post.date),
-  }
-}
-
-const RSS = defineAsyncComponent(async () => plainText(await renderRSS()))
+let items = $computed(() => getPosts().value.map(post => ({
+  title: post.title,
+  link: `${url}${post.href}`,
+  date: new Date(post.date),
+  description: post.excerpt,
+  content: post.render,
+  author: [
+    {
+      name: post.author,
+      link: post.twitter
+        ? `https://twitter.com/${post.twitter}`
+        : undefined,
+    },
+  ],
+})))
 </script>
 
 <template>
-  <RSS/>
 </template>

--- a/playground/the-vue-point/src/pages/feed.vue
+++ b/playground/the-vue-point/src/pages/feed.vue
@@ -38,4 +38,5 @@ let items = $computed(() => getPosts().value.map(post => ({
 </script>
 
 <template>
+  <RenderFeed format="rss" v-bind="{ options, items }"/>
 </template>

--- a/playground/the-vue-point/src/pages/feed.vue
+++ b/playground/the-vue-point/src/pages/feed.vue
@@ -4,11 +4,12 @@ path: /feed.rss
 
 <script setup lang="ts">
 import { getPosts } from '~/logic/posts'
+import type { FeedOptions, FeedItem } from '@islands/feed'
 
 const { site } = usePage()
 const url = site.url
 
-const options = {
+const options: FeedOptions = {
   title: 'The Vue Point',
   description: 'The official blog for the Vue.js project',
   id: url,
@@ -20,7 +21,7 @@ const options = {
     'Copyright (c) 2021-present, Yuxi (Evan) You and blog contributors',
 }
 
-let items = $computed(() => getPosts().value.map(post => ({
+let items = $computed(() => getPosts().value.map<FeedItem>(post => ({
   title: post.title,
   link: `${url}${post.href}`,
   date: new Date(post.date),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,12 +70,23 @@ importers:
       '@preact/preset-vite': 2.1.5_preact@10.5.15
       '@vueuse/core': 6.9.2
       autoprefixer: 10.4.0
-      iles: 0.7.1
+      iles: 0.7.2
       postcss-nesting: 8.0.1
       preact-render-to-string: 5.1.19_preact@10.5.15
       vite-plugin-inspect: 0.3.11
       vite-plugin-windicss: 1.5.1
       vue-tsc: 0.29.8
+
+  packages/feed:
+    specifiers:
+      feed: ^4.2
+      iles: workspace:*
+      vue: ^3.2
+    dependencies:
+      feed: 4.2.2
+    devDependencies:
+      iles: link:../iles
+      vue: 3.2.24
 
   packages/headings:
     specifiers:
@@ -132,6 +143,7 @@ importers:
   packages/iles:
     specifiers:
       '@antfu/install-pkg': ^0.1.0
+      '@islands/feed': workspace:^0.1.0
       '@islands/headings': workspace:^0.1.0
       '@islands/hydration': workspace:^0.3.3
       '@islands/icons': workspace:^0.1.0
@@ -205,6 +217,7 @@ importers:
       xdm: 3.3.1
     devDependencies:
       '@antfu/install-pkg': 0.1.0
+      '@islands/feed': link:../feed
       '@islands/headings': link:../headings
       '@islands/icons': link:../icons
       '@islands/prism': link:../prism
@@ -337,16 +350,16 @@ importers:
   playground/the-vue-point:
     specifiers:
       '@iconify-json/carbon': ^1.0.7
+      '@islands/feed': workspace:*
       '@islands/icons': workspace:*
       '@islands/prism': workspace:*
-      feed: ^4.2.1
       iles: workspace:*
       vite-plugin-windicss: ^1.5.1
     devDependencies:
       '@iconify-json/carbon': 1.0.7
+      '@islands/feed': link:../../packages/feed
       '@islands/icons': link:../../packages/icons
       '@islands/prism': link:../../packages/prism
-      feed: 4.2.2
       iles: link:../../packages/iles
       vite-plugin-windicss: 1.5.1
 
@@ -1268,8 +1281,8 @@ packages:
       - supports-color
     dev: true
 
-  /@islands/pages/0.7.0:
-    resolution: {integrity: sha512-c6Uuz6ldGUxmbB6SqabGBMyl9r/88hzsl8g1wMVBUVNePPpGzZzMSoMwoKzdh0POa83Dp5v3G362MqzuUK/Z9g==}
+  /@islands/pages/0.7.1:
+    resolution: {integrity: sha512-o3WWDNzQ4W7wuYE4CSZ19yI6/aQt1eWoUt7r2biK8Sv5xM8VQL8g6vBwe0/kFSpvM6QoKeZGO+wVauhaGxIC7w==}
     dependencies:
       debug: 4.3.3
       deep-equal: 2.0.5
@@ -4093,7 +4106,7 @@ packages:
     engines: {node: '>=0.4.0'}
     dependencies:
       xml-js: 1.6.11
-    dev: true
+    dev: false
 
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -4535,14 +4548,14 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /iles/0.7.1:
-    resolution: {integrity: sha512-tLftWV445rDzs2aETHQxcrPuzPmLQWWBh6IyqL5jWiJCzZLZKgSka1QAKqHLpl2vCx3K0JbvtscxEYAJtqACDw==}
+  /iles/0.7.2:
+    resolution: {integrity: sha512-lJCC/I/G2UYSZwYRe/qFax+jMgtYmsV+nG0Amhht3TuQU0p1MMrr+iDjqV+szuOC0r6XestkrPj2ZXNlfBE0FA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
       '@islands/hydration': 0.3.3_vue@3.2.24
       '@islands/mdx': 0.7.1
-      '@islands/pages': 0.7.0
+      '@islands/pages': 0.7.1
       '@islands/prerender': 0.3.1_vue@3.2.24
       '@nuxt/devalue': 2.0.0
       '@vitejs/plugin-vue': 1.10.2_vite@2.7.0
@@ -6771,7 +6784,7 @@ packages:
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: true
+    dev: false
 
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -8203,7 +8216,7 @@ packages:
     hasBin: true
     dependencies:
       sax: 1.2.4
-    dev: true
+    dev: false
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - packages/prerender/
   - packages/headings/
   - packages/mdx/
+  - packages/feed/
   - packages/icons/
   - packages/pages/
   - packages/prism/


### PR DESCRIPTION
[îles]: https://github.com/ElMassimo/iles
[routing]: https://iles-docs.netlify.app/guide/routing
[feed]: https://github.com/jpmonette/feed

### Description 📖

This pull request adds a new `@islands/feed` module, which provides:

- 📻 supports RSS, Atom, and JSON feeds

- ⚡️ HMR during development to debug the result

- 💪🏼 type autocompletion, powered by [`feed`][feed]