### PR TITLE
feat: use internal not found page during development as it's more helpful

### DIFF
--- a/packages/iles/src/client/app/index.ts
+++ b/packages/iles/src/client/app/index.ts
@@ -21,11 +21,6 @@ const newApp = import.meta.env.SSR ? createSSRApp : createClientApp
 function createRouter (base: string | undefined, routerOptions: Partial<RouterOptions>) {
   if (base === '/') base = undefined
 
-  // Handle 404s in development.
-  if (import.meta.env.DEV)
-    // @ts-ignore
-    routes.push({ path: '/:path(.*)*', name: 'NotFound', component: () => import('@islands/components/NotFound') })
-
   return createVueRouter({
     scrollBehavior: (current, previous, savedPosition) => {
       if (savedPosition) return savedPosition

--- a/packages/iles/src/node/config.ts
+++ b/packages/iles/src/node/config.ts
@@ -235,7 +235,7 @@ function appConfigDefaults (appConfig: AppConfig, userConfig: UserConfig, env: C
     // Handle 404s in development.
     extendRoutes (routes) {
       if (isDevelopment)
-        routes.push({ path: '/:zzz(.*)*', name: 'NotFoundInDev', componentFilename: '@islands/components/NotFound' })
+        return [...routes, { path: '/:zzz(.*)*', name: 'NotFoundInDev', componentFilename: '@islands/components/NotFound' }]
     },
     markdown: {
       jsxRuntime: 'automatic',

--- a/packages/iles/src/node/plugin/plugin.ts
+++ b/packages/iles/src/node/plugin/plugin.ts
@@ -66,13 +66,8 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
         if (id === APP_CONFIG_REQUEST_PATH || id === USER_APP_REQUEST_PATH || id === USER_SITE_REQUEST_PATH)
           return id
 
-        if (id === NOT_FOUND_REQUEST_PATH) {
-          for (const extension of ['vue', 'mdx', 'md', 'jsx']) {
-            const path = resolve(appConfig.pagesDir, `404.${extension}`)
-            if (await exists(path)) return path
-          }
+        if (id === NOT_FOUND_REQUEST_PATH)
           return NOT_FOUND_COMPONENT_PATH
-        }
 
         // Prevent import analysis failure if the default layout doesn't exist.
         if (id === defaultLayoutPath) return resolve(root, id.slice(1))

--- a/packages/iles/tests/not-found.spec.ts
+++ b/packages/iles/tests/not-found.spec.ts
@@ -4,6 +4,6 @@ import NotFound from '@islands/components/NotFound'
 
 describe('not found component', () => {
   test('resolves to existing component', async () => {
-    expect(NotFound.title).toEqual('Not Found')
+    expect(NotFound.name).toEqual('NotFound')
   })
 })


### PR DESCRIPTION
### Description 📖

This pull request makes the internal not found page the default in development instead of showing a user-provided 404.

### Background 📜 

Previously, the internal not found page was only used if the user did not provide a `404` page, simulating the behavior of the deployed site (most service providers will use `/404.html` if available).

In practice, it's more helpful to see an explicit message when this happens in development, the user-provided `404` can be tested by navigating to it directly instead.

### Screenshots 📷

<img width="764" alt="Screen Shot 2021-12-27 at 17 24 51" src="https://user-images.githubusercontent.com/1158253/147505042-1f0f9a83-71bb-4023-9a08-59b505a0811c.png">

