### PR TITLE
fix: `ERR_REQUIRE_ESM` error when project type is set to `module`

### DIFF
--- a/packages/iles/src/node/build/bundle.ts
+++ b/packages/iles/src/node/build/bundle.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import type { RollupOutput } from 'rollup'
 import type { Plugin } from 'vite'
 import glob from 'fast-glob'
-import { relative, dirname, resolve } from 'pathe'
+import { relative, dirname, resolve, join } from 'pathe'
 import { build, mergeConfig as mergeViteConfig, UserConfig as ViteUserConfig } from 'vite'
 import { APP_PATH } from '../alias'
 import { AppConfig } from '../shared'
@@ -51,6 +51,7 @@ async function bundleWithVite (config: AppConfig, entrypoints: string[] | Entryp
       htmlBuild
         ? moveHtmlPagesPlugin(config)
         : !ssr && removeJsPlugin(),
+      ssr && addCommonJsPackagePlugin(config),
     ],
     build: {
       ssr,
@@ -100,5 +101,15 @@ function moveHtmlPagesPlugin (config: AppConfig): Plugin {
       }))
       rm(resolve(outDir, relative(config.root, config.srcDir)))
     },
+  }
+}
+
+// Internal: Add a `package.json` file specifying the type of files as CJS.
+function addCommonJsPackagePlugin(config: AppConfig) {
+  return {
+    name: 'iles:add-common-js-package-plugin',
+    writeBundle() {
+      fs.writeFile(join(config.tempDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+    }
   }
 }


### PR DESCRIPTION
### Description 📖

This pull request fix a bug where iles fails to build when the project has a package.json file with its type set to `module`. See the [reproduction repository](https://github.com/titouanmathis/iles-esm-cjs-conflict-reproduction) for an example.

### Background 📜

This was happening because the files in the temporary directory are in CJS with the `.js` extension. When the root package.json type is set to `module`, files in CJS format should have a `.cjs` extension.

### The Fix 🔨

I tried several fixes bundling iles to ESM with `tsup` but it is not as simple as changing the format in the `tsup.config.ts` file and iles should detect the type of project to work correctly.

The simplest fix is adding a package.json file in the temporary directory with the type set to `commonjs`.

### Screenshots 📷

With `"type": "module"` in the root `package.json` file:

![Capture d’écran 2022-01-02 à 14 37 29](https://user-images.githubusercontent.com/250145/147879269-e364a652-9732-4f2d-a115-8c483e2f268d.png)

When adding a package.json file with `"type": "commonjs"` in the `.iles-ssg-temp` directory:

![Capture d’écran 2022-01-02 à 14 38 04](https://user-images.githubusercontent.com/250145/147879322-d670a78f-c851-4d35-9b4b-41b8bde6e48e.png)