### PR TITLE
Fix anchor links in MDX files when prettyUrls is false

### DIFF
--- a/packages/mdx/src/utils.ts
+++ b/packages/mdx/src/utils.ts
@@ -21,10 +21,20 @@ export function isString (val: any): val is string {
   return typeof val === 'string'
 }
 
-export function toExplicitHtmlPath (path: string) {
+export function toExplicitHtmlPath (url: string) {
+  const [path, anchor] = url.split('#', 2)
   const ext = extname(path)
-  if (isExternal(path) || (ext && ext !== '.html')) return path
-  if (path.endsWith('/')) return path
-  if (path.endsWith('/index.html')) return path.replace(/\/index\.html$/, '/')
-  return `${path}.html`
+  if (isExternal(path) || (ext && ext !== '.html') || path === '') return url
+  if (path.endsWith('/')) return url
+
+  let htmlPath
+  if (path.endsWith('/index.html'))
+    htmlPath = path.replace(/\/index\.html$/, '/')
+  else
+    htmlPath = `${path}.html`
+
+  if (anchor)
+    return `${htmlPath}#${anchor}`
+  else
+    return htmlPath
 }


### PR DESCRIPTION
### Description 📖

This attempts to fix a bug that appears to be present when `prettyUrls: false` which prevents MDX pages from linking to anchor tags on the page. Here is a reproduction of the issue: https://github.com/GUI/iles-debug-app/compare/anchor-links-pretty-urls

### Background 📜

If the app is configured with `prettyUrls: false`, then anchor links in MDX files may not behave as expected. For example, a link like:

```md
[foo](#bar)
```

Will be generated in the output as:

```html
<a href="#bar.html">foo</a>
```

Instead of remaining `href="#bar"`, like expected (since the anchor of '#bar.html` probably won't exist on the page).

Similarly, a link to `/foo#bar` will get translated to `/foo#bar.html` instead of what I think would be intended by how other URLs get rewritten (in which case, I think `/foo.html#bar` would be expected).

### The Fix 🔨

This fixes the issue by skipping the MDX URL rewriting when anchor tags on the current page (no path is present) are encountered. For anchor links on other pages, the anchor is split from the path, and then the existing path rules are used, adding the anchor back in afterwards.

Using a URL parsing library, instead of simply splitting the string by `#` may be more robust, but Node.js's `URL` class doesn't handle relative links or fragment-only links, so it won't work for this use-case. But I think this simple splitting approach will hopefully meet the needs here.

But also welcome to any other suggestions for ways to fix this. Thanks!