### PR TITLE
Fix type for siteUrl config option

### DIFF
--- a/docs/src/pages/config/index.mdx
+++ b/docs/src/pages/config/index.mdx
@@ -125,8 +125,7 @@ You must provide <kbd>[siteUrl](#siteurl)</kbd> to enable sitemap generation.
 
 ### `siteUrl`
 
-- **Type:** `'vue' | 'preact' | 'solid'`
-- **Default:** `'vue'`
+- **Type:** `string`
 
 URL for the [site] in production, used to generate absolute URLs for the [sitemap]
 and social [meta tags].


### PR DESCRIPTION
### Description 📖

This pull request fixes the type shown in the docs for the `siteUrl` config option.

### Background 📜

This was happening because the `siteUrl` config option seemed to have the type from the `jsx` option.

### The Fix 🔨

By changing type to `string` and removing the default, it matches the actual type: https://github.com/ElMassimo/iles/blob/main/packages/iles/types/shared.d.ts#L201