### PR TITLE
feat: add built-in support for drafts in pages and documents

### DIFF
--- a/docs/src/components/TheSidebar.vue
+++ b/docs/src/components/TheSidebar.vue
@@ -16,7 +16,8 @@ export function onLoad () {
     if (open) {
       bg.classList.remove('hidden')
       bg.classList.remove('opacity-0')
-    } else {
+    }
+    else {
       bg.classList.add('opacity-0')
       panel.addEventListener('transitionend', e => bg.classList.add('hidden'), { once: true })
     }

--- a/docs/src/pages/config/index.mdx
+++ b/docs/src/pages/config/index.mdx
@@ -15,6 +15,9 @@ sidebar: auto
 [deployment]: /guide/deployment 
 [VitePress]: /faqs#vitepress
 [turbo]: /guide/turbo
+[documents]: /guide/documents
+[drafts]: /guide/markdown
+[useDocuments]: /guide/documents
 
 # Configuration
 
@@ -55,6 +58,17 @@ export default defineConfig({
   jsx: 'preact',
 })
 ```
+
+### `drafts`
+
+- **Type:** `boolean`
+- **Default:** `true` in development, `false` when building
+
+Whether to include [drafts] in pages and [documents].
+
+By default drafts will be displayed during development, but will be excluded when building the site.
+
+> When disabled, drafts will also be excluded from <kbd>[useDocuments]</kbd>.
 
 ### `modules`
 

--- a/docs/src/pages/guide/markdown.mdx
+++ b/docs/src/pages/guide/markdown.mdx
@@ -8,6 +8,7 @@
 [mdxComponents]: /config#mdxcomponents
 [frameworks]: /guide/frameworks
 [enhanceApp]: /config#enhanceapp
+[drafts]: /config#drafts
 
 # Markdown 📖
 
@@ -57,6 +58,19 @@ The `filename` and the page `href` can be accessed through [`meta`][meta].
 ```mdx
 <SuggestChangesLink filename={ meta.filename }/>
 ```
+
+### Markdown Drafts 📝
+
+You can mark an individual document as _unpublished_ by using `draft: true`.
+
+```mdx
+---
+title: Still not ready
+draft: true
+---
+```
+
+By default, draft pages and documents will be displayed in development, but will be excluded when building the site. Use <kbd>[drafts]</kbd> to override this behavior.
 
 ## Components in Markdown 🧱
 

--- a/packages/feed/src/feed.ts
+++ b/packages/feed/src/feed.ts
@@ -1,5 +1,5 @@
-import { dirname, join } from 'pathe'
 import { fileURLToPath } from 'url'
+import { dirname, join } from 'pathe'
 import type { IlesModule } from 'iles'
 
 export * from './types'

--- a/packages/iles/src/node/config.ts
+++ b/packages/iles/src/node/config.ts
@@ -190,11 +190,12 @@ function inferJSX (config: UserConfig) {
 
 function appConfigDefaults (appConfig: AppConfig, userConfig: UserConfig, env: ConfigEnv): AppConfig {
   const { root } = appConfig
-  const { jsx = inferJSX(userConfig) } = userConfig
   const isDevelopment = env.mode === 'development'
+  const { drafts = isDevelopment, jsx = inferJSX(userConfig) } = userConfig
 
   return {
     debug: true,
+    drafts,
     turbo: false,
     jsx,
     root,
@@ -236,6 +237,9 @@ function appConfigDefaults (appConfig: AppConfig, userConfig: UserConfig, env: C
     extendRoutes (routes) {
       if (isDevelopment)
         return [...routes, { path: '/:zzz(.*)*', name: 'NotFoundInDev', componentFilename: '@islands/components/NotFound' }]
+      else if (!drafts) {
+        return routes.filter(route => !route.frontmatter?.draft)
+      }
     },
     markdown: {
       jsxRuntime: 'automatic',

--- a/packages/iles/src/node/config.ts
+++ b/packages/iles/src/node/config.ts
@@ -237,9 +237,8 @@ function appConfigDefaults (appConfig: AppConfig, userConfig: UserConfig, env: C
     extendRoutes (routes) {
       if (isDevelopment)
         return [...routes, { path: '/:zzz(.*)*', name: 'NotFoundInDev', componentFilename: '@islands/components/NotFound' }]
-      else if (!drafts) {
+      else if (!drafts)
         return routes.filter(route => !route.frontmatter?.draft)
-      }
     },
     markdown: {
       jsxRuntime: 'automatic',

--- a/packages/iles/types/shared.d.ts
+++ b/packages/iles/types/shared.d.ts
@@ -247,12 +247,17 @@ export interface RequiredConfig {
 }
 
 export interface UserConfig extends Partial<RequiredConfig>, Partial<IlesModule> {
+  /**
+   * Whether to display drafts in documents and pages.
+   */
+  drafts?: boolean
   modules?: IlesModuleOption[]
 }
 
 export interface AppConfig extends RequiredConfig, Omit<BaseIlesConfig, 'pagesDir'> {
   base: string
   root: string
+  drafts: boolean
   configPath: string
   modules: IlesModule[]
   namedPlugins: NamedPlugins

--- a/packages/mdx/src/mdx.ts
+++ b/packages/mdx/src/mdx.ts
@@ -1,11 +1,11 @@
 import remarkFrontmatter from 'remark-frontmatter'
 
+import type { VFile } from '@mdx-js/mdx/lib/plugin/recma-stringify'
 import recmaPlugin from './recma-plugin'
 import mdxPlugins from './mdx-vite-plugins'
 import { remarkInternalHrefs } from './remark-internal-hrefs'
 import { remarkMdxImages } from './remark-mdx-images'
 import { rehypeRawExpressions } from './rehype-raw-expressions'
-import type { VFile } from '@mdx-js/mdx/lib/plugin/recma-stringify'
 
 /**
  * An iles module that injects a recma plugin that transforms MDX to allow


### PR DESCRIPTION
### Description 📖

This pull request adds support for _unpublished_ documents, which is useful to commit work in progress.

### Documentation 📖 

You can mark an individual document as _unpublished_ by using `draft: true`.

```mdx
---
title: Still not ready
draft: true
---
```

By default, draft pages and documents will be displayed in development, but will be excluded when building the site. Use the <kbd>drafts</kbd> setting in `iles.config.ts` to override this behavior.
