### PR TITLE
fix: explicitly export types from composable

### DIFF
--- a/packages/iles/src/client/index.ts
+++ b/packages/iles/src/client/index.ts
@@ -3,12 +3,13 @@
 
 // Generic Types
 export type { Router, RouteRecordRaw } from './shared'
+export type { VueRenderable } from './app/composables/vueRenderer'
 
 // Composables
 export { useAppConfig } from './app/composables/appConfig'
 export { usePage, computedInPage } from './app/composables/pageData'
 export { useMDXComponents, provideMDXComponents } from './app/composables/mdxComponents'
-export { useVueRenderer, VueRenderable } from './app/composables/vueRenderer'
+export { useVueRenderer } from './app/composables/vueRenderer'
 export { useRouter, useRoute } from 'vue-router'
 export { useHead } from '@vueuse/head'
 


### PR DESCRIPTION
### Description 📖

This pull request fixes the type checking in [my îles project](https://github.com/johannschopplich/zahnarzt-schopplich.de).

### Background 📜

This was happening because of the following TS error:

```
node_modules/.pnpm/iles@0.7.37/node_modules/iles/dist/client/index.ts:11:26 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

11 export { useVueRenderer, VueRenderable } from './app/composables/vueRenderer'
                            ~~~~~~~~~~~~~


Found 1 error in node_modules/.pnpm/iles@0.7.37/node_modules/iles/dist/client/index.ts:11
```

### The Fix 🔨

By adding an explicit type export, the type checking should be fine.

### Screenshots 📷

None available.