### PR TITLE
chore: update pnpm filter pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build:all": "pnpm nx run-many --target=build --all --exclude docs --exclude vue-blog",
     "lint:all": "pnpm nx run-many --target=lint --all",
-    "dev": "pnpm -r --parallel --filter packages run dev",
+    "dev": "pnpm -r --parallel --filter ./packages/** run dev",
     "docs": "npm -C docs run dev",
     "docs:build": "npm -C docs run build",
     "docs:now": "npm -C docs run now",


### PR DESCRIPTION
### Description 📖

update pnpm filter pattern

### Background 📜

In pnpm v6, in order to pick packages under a certain directory, the following filter was used: --filter=./apps

In pnpm v7, a glob should be used: --filter=./apps/**

### The Fix 🔨

This is an addition to #117. I accidentally forgot about it.
