### PR TITLE
docs(pwa): fix `ReloadPrompt` link

### DIFF
--- a/docs/src/pages/guide/pwa.mdx
+++ b/docs/src/pages/guide/pwa.mdx
@@ -5,7 +5,7 @@
 [prompt]: https://vite-plugin-pwa.netlify.app/guide/prompt-for-update.html
 [autoUpdate]: https://vite-plugin-pwa.netlify.app/guide/auto-update.html
 [PWA configuration]: https://github.com/ElMassimo/iles/blob/main/docs/iles.config.ts
-[ReloadPrompt component]: https://github.com/ElMassimo/iles/blob/main/docs/components/ReloadPrompt.vue
+[ReloadPrompt component]: https://github.com/ElMassimo/iles/blob/main/docs/src/components/ReloadPrompt.vue
 [client script block]: /guide/client-scripts
 [@userquin]: https://twitter.com/userquin
 


### PR DESCRIPTION
### Description 📖

The link for `ReloadPrompt`  on PWA docs is wrong

### Background 📜

This was happening because the link is worng

### The Fix 🔨

By changing the `pwa.mdx` adding `src` on the link

### Screenshots 📷

no