### PR TITLE
fix: prefetch support on Firefox

### DIFF
--- a/packages/iles/turbo.js
+++ b/packages/iles/turbo.js
@@ -151,7 +151,12 @@ function activateScript (el) {
 
 function hasPrefetch (link) {
   link = createElement()
-  return link.relList && link.relList.supports && link.relList.supports('prefetch')
+  return (
+    !/firefox/i.test(navigator.userAgent) &&
+    link.relList &&
+    link.relList.supports &&
+    link.relList.supports('prefetch')
+  );
 }
 
 function prefetchWithLinkTag (url, link) {


### PR DESCRIPTION
### Description 📖

I noticed that when enabling the turbo mode, links were not prefetched with Firefox.

### Background 📜

It appears that Firefox does not support dynamically inserted prefetch links. This means that testing `link.relList.supports('prefetch')` will return true. 

See the following Stack Overflow threads:

- https://stackoverflow.com/questions/30996119/link-rel-prefetch-in-firefox-network-panel
- https://stackoverflow.com/questions/24000598/firefox-add-on-prefetching-with-link-tag

### The Fix 🔨

This PR adds a test on the user-agent before testing the support of prefetch links, enabling the fallback prefetch strategy with `fetch()`. 

### Screenshots 📷

I have no screenshots, let me know if you need some.
