### PR TITLE
Use type imports for imports not used as values

### DIFF
--- a/packages/iles/src/client/app/composables/appConfig.ts
+++ b/packages/iles/src/client/app/composables/appConfig.ts
@@ -1,5 +1,7 @@
-import { App, InjectionKey, inject } from 'vue'
-import { AppClientConfig } from '../../shared'
+import { inject } from 'vue'
+
+import type { App, InjectionKey } from 'vue'
+import type { AppClientConfig } from '../../shared'
 
 export const appConfigSymbol: InjectionKey<AppClientConfig> = Symbol('[iles-app-config]')
 

--- a/packages/iles/src/client/app/composables/islandDefinitions.ts
+++ b/packages/iles/src/client/app/composables/islandDefinitions.ts
@@ -1,6 +1,7 @@
 import { useSSRContext } from 'vue'
 import { useRoute } from 'vue-router'
-import { IslandDefinition } from '../../shared'
+
+import type { IslandDefinition } from '../../shared'
 
 export function useIslandsForPath<T = any> (): IslandDefinition[] {
   const context = useSSRContext()

--- a/packages/iles/src/client/app/composables/reactivity.ts
+++ b/packages/iles/src/client/app/composables/reactivity.ts
@@ -1,4 +1,6 @@
-import { Ref, reactive } from 'vue'
+import { reactive } from 'vue'
+
+import type { Ref } from 'vue'
 
 /**
  * Converts ref to a reactive value.

--- a/packages/iles/src/client/index.ts
+++ b/packages/iles/src/client/index.ts
@@ -14,7 +14,7 @@ export { useRouter, useRoute } from 'vue-router'
 export { useHead } from '@vueuse/head'
 
 import type { ComponentOptionsWithoutProps, ComputedRef } from 'vue'
-import { UserApp, GetStaticPaths, Document } from '../../types/shared'
+import type { UserApp, GetStaticPaths, Document } from '../../types/shared'
 
 export function useDocuments<T = void> (globPattern: string): ComputedRef<Document<T>[]> {
   throw new Error(`Unresolved useDocuments('${globPattern}')`)


### PR DESCRIPTION
### Description 📖

This pull request changes some regular imports to type imports to solve #138.

### Background 📜

Refer to #138 for the cause of the issue.

### The Fix 🔨

By changing regular imports to type imports we can prevent TS from calling them out as errors and unblock the builds.
