### PR TITLE
feat: display nice app name for islands in vue devtools (closes #140)

### DIFF
--- a/packages/hydration/vue.ts
+++ b/packages/hydration/vue.ts
@@ -1,5 +1,5 @@
 import { h, createApp as createClientApp, createStaticVNode, createSSRApp } from 'vue'
-import type { DefineComponent as Component } from 'vue'
+import type { DefineComponent as Component, Component as App } from 'vue'
 import type { Props, Slots } from './types'
 import { onDispose } from './hydration'
 
@@ -11,7 +11,12 @@ export default function createVueIsland (component: Component, id: string, el: E
     return [slotName, () => (createStaticVNode as any)(content)]
   }))
 
-  const app = createVueApp({ render: () => h(component, props, slotFns) })
+  const appDefinition: App = { render: () => h(component, props, slotFns) }
+
+  if (import.meta.env.DEV)
+    appDefinition.name = 'Island: ' + nameFromFile(component.__file)
+
+  const app = createVueApp(appDefinition)
   app.mount(el!, Boolean(slots))
 
   if (import.meta.env.DISPOSE_ISLANDS)
@@ -19,4 +24,9 @@ export default function createVueIsland (component: Component, id: string, el: E
 
   if (import.meta.env.DEV)
     (window as any).__ILE_DEVTOOLS__?.onHydration({ id, el, props, slots, component })
+}
+
+function nameFromFile (file?: string) {
+  const regex = /(\w+?)(?:\.vue)?$/
+  return file?.match(regex)?.[1] || file
 }

--- a/packages/hydration/vue.ts
+++ b/packages/hydration/vue.ts
@@ -14,7 +14,7 @@ export default function createVueIsland (component: Component, id: string, el: E
   const appDefinition: App = { render: () => h(component, props, slotFns) }
 
   if (import.meta.env.DEV)
-    appDefinition.name = 'Island: ' + nameFromFile(component.__file)
+    appDefinition.name = `Island: ${nameFromFile(component.__file)}`
 
   const app = createVueApp(appDefinition)
   app.mount(el!, Boolean(slots))


### PR DESCRIPTION
### Description 📖

This pull request extends `@islands/hydration` to name Vue Island Apps after their root component.

It uses `import.meta.env.DEV` so it has no impact in the compiled bundle.

### Screenshots 📷

#### Before

![image](https://user-images.githubusercontent.com/1158253/175546015-066b1648-45b0-4c02-8a7c-67a5552e548c.png)

#### After

<img width="1728" alt="Screen Shot 2022-06-24 at 10 22 45" src="https://user-images.githubusercontent.com/1158253/175546070-0b4e5618-c4f3-4758-85a1-ca82c43bfeea.png">

