### PR TITLE
feat: use `ManifestTransform` when using `@islands/pwa`

### DIFF
--- a/docs/iles.config.ts
+++ b/docs/iles.config.ts
@@ -52,7 +52,6 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // exclude html files here: the pwa module will calculate their hash and add them to the sw precache
         globPatterns: ['**/*.{js,css,svg,ico,png,avif,json,xml,html}'],
         runtimeCaching: [
           {

--- a/docs/iles.config.ts
+++ b/docs/iles.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       },
       workbox: {
         // exclude html files here: the pwa module will calculate their hash and add them to the sw precache
-        globPatterns: ['**/*.{js,css,svg,ico,png,avif,json,xml}'],
+        globPatterns: ['**/*.{js,css,svg,ico,png,avif,json,xml,html}'],
         runtimeCaching: [
           {
             urlPattern: new RegExp('https://unpkg.com/.*', 'i'),

--- a/docs/src/pages/guide/pwa.mdx
+++ b/docs/src/pages/guide/pwa.mdx
@@ -65,19 +65,5 @@ registerSW({ immediate: true })
 ## Specifying the Vite plugin manually
 
 When specifying <kbd>[vite-plugin-pwa]</kbd> manually, <kbd>[@islands/pwa]</kbd>
-will detect it and use it:
+will detect it and will throw an error, you must configure it using <kbd>[@islands/pwa]</kbd>.
 
-```ts
-import { defineConfig } from 'iles'
-import { VitePWA } from 'vite-plugin-pwa'
-
-export default defineConfig({
-  modules: [
-    '@islands/pwa',
-  ],
-  vite: {
-    plugins: [VitePWA(options)],
-  },
-})
-```
-<Caption>`iles.config.ts`</Caption>

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/ElMassimo/iles",
   "bugs": "https://github.com/ElMassimo/iles/issues",
   "dependencies": {
-    "vite-plugin-pwa": "^0.12.0"
+    "vite-plugin-pwa": "^0.12.2"
   },
   "devDependencies": {
     "iles": "workspace:*"

--- a/packages/pwa/src/pwa.ts
+++ b/packages/pwa/src/pwa.ts
@@ -2,67 +2,26 @@ import fs from 'fs'
 import crypto from 'crypto'
 import { resolve } from 'path'
 import { performance } from 'perf_hooks'
-import type { IlesModule, UserConfig } from 'iles'
+import type { IlesModule, RouteToRender, UserConfig } from 'iles'
 import type { VitePluginPWAAPI, VitePWAOptions } from 'vite-plugin-pwa'
-import type { ManifestEntry } from 'workbox-build'
+import type { ManifestEntry, ManifestTransform } from 'workbox-build'
 import { VitePWA } from 'vite-plugin-pwa'
+
+interface ManifestTransformData {
+  outDir: string
+  pages: RouteToRender[]
+}
+
+interface EnableManifestTransformData {
+  enable: boolean
+  data?: ManifestTransformData
+}
+
+type EnableManifestTransform = () => EnableManifestTransformData
 
 function timeSince (start: number): string {
   const diff = performance.now() - start
   return diff < 750 ? `${Math.round(diff)}ms` : `${(diff / 1000).toFixed(1)}s`
-}
-
-function configureDefaults (config: UserConfig, options: Partial<VitePWAOptions> = {}): Partial<VitePWAOptions> {
-  const {
-    strategies = 'generateSW',
-    registerType = 'prompt',
-    injectRegister,
-    workbox = {},
-    injectManifest = {},
-    ...rest
-  } = options
-
-  if (strategies === 'generateSW') {
-    const useWorkbox = { ...workbox }
-    const newOptions: Partial<VitePWAOptions> = {
-      ...rest,
-      strategies,
-      registerType,
-      injectRegister,
-    }
-    // we use route names: use Vite base or its default
-    if (!useWorkbox.navigateFallback || useWorkbox.navigateFallback.endsWith('.html'))
-      useWorkbox.navigateFallback = config.vite?.base ?? '/'
-
-    if (registerType === 'autoUpdate') {
-      if (useWorkbox.clientsClaim === undefined)
-        useWorkbox.clientsClaim = true
-
-      if (useWorkbox.skipWaiting === undefined)
-        useWorkbox.skipWaiting = true
-    }
-
-    // we don't need registerSW.js if not configured
-    if (injectRegister === undefined)
-      newOptions.injectRegister = null
-
-    newOptions.workbox = useWorkbox
-
-    return newOptions
-  }
-
-  // we don't need registerSW.js if not configured
-  if (injectRegister === undefined) {
-    return {
-      ...rest,
-      strategies,
-      registerType,
-      injectManifest,
-      injectRegister: null,
-    }
-  }
-
-  return options
 }
 
 function buildManifestEntry (
@@ -87,6 +46,110 @@ function buildManifestEntry (
   })
 }
 
+function buildManifestEntryTransform (
+  url: string,
+  path: string,
+): Promise<ManifestEntry & { size: number }> {
+  return buildManifestEntry(url, path).then(({ url, revision }) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const { size } = fs.statSync(path)
+        return resolve({ url, revision, size })
+      }
+      catch (e) {
+        reject(e)
+      }
+    })
+  })
+}
+
+function createManifestTransform (enableManifestTransform: EnableManifestTransform): ManifestTransform {
+  return async (entries) => {
+    const { enable, data } = enableManifestTransform()
+    console.log(`Calling ManifestTransform: ${enable}`)
+    if (enable && data) {
+      const { outDir, pages } = data
+      console.log(entries.filter(e => e.url.endsWith('.html')))
+      const manifest = entries.filter(e => !e.url.endsWith('.html'))
+      const addRoutes = await Promise.all(pages.map((r) => {
+        return buildManifestEntryTransform(r.path, resolve(outDir, r.outputFilename))
+      }))
+      console.log(addRoutes)
+      manifest.push(...addRoutes)
+      return { manifest }
+    }
+
+    return { manifest: entries }
+  }
+}
+
+function configureDefaults (
+  config: UserConfig,
+  enableManifestTransform: EnableManifestTransform,
+  options: Partial<VitePWAOptions> = {},
+): Partial<VitePWAOptions> {
+  const {
+    strategies = 'generateSW',
+    registerType = 'prompt',
+    injectRegister,
+    workbox = {},
+    injectManifest = {},
+    ...rest
+  } = options
+
+  if (strategies === 'generateSW') {
+    const useWorkbox = { ...workbox }
+    const newOptions: Partial<VitePWAOptions> = {
+      ...rest,
+      strategies,
+      registerType,
+      injectRegister,
+    }
+    const prettyUrls = config.prettyUrls ?? true
+    if (!useWorkbox.navigateFallback && prettyUrls)
+      useWorkbox.navigateFallback = config.vite?.base ?? '/'
+
+    // TODO: remove this when https://github.com/antfu/vite-plugin-pwa/pull/306 released
+    if (registerType === 'autoUpdate') {
+      if (useWorkbox.clientsClaim === undefined)
+        useWorkbox.clientsClaim = true
+
+      if (useWorkbox.skipWaiting === undefined)
+        useWorkbox.skipWaiting = true
+    }
+
+    // we don't need registerSW.js if not configured
+    if (injectRegister === undefined)
+      newOptions.injectRegister = null
+
+    newOptions.workbox = useWorkbox
+
+    newOptions.workbox.manifestTransforms = newOptions.workbox.manifestTransforms ?? []
+    newOptions.workbox.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+
+    return newOptions
+  }
+
+  // we don't need registerSW.js if not configured
+  if (injectRegister === undefined) {
+    injectManifest.manifestTransforms = injectManifest.manifestTransforms ?? []
+    injectManifest.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+    return {
+      ...rest,
+      strategies,
+      registerType,
+      injectManifest,
+      injectRegister: null,
+    }
+  }
+
+  options.injectManifest = options.injectManifest ?? {}
+  options.injectManifest.manifestTransforms = injectManifest.manifestTransforms ?? []
+  options.injectManifest.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+
+  return options
+}
+
 /**
  * An iles module that configures vite-plugin-pwa and
  * regenerates the PWA when SSG is finished.
@@ -95,6 +158,9 @@ function buildManifestEntry (
  */
 export default function IlesPWA (options: Partial<VitePWAOptions> = {}): IlesModule {
   let api: VitePluginPWAAPI | undefined
+  let enable = false
+  let data: ManifestTransformData | undefined
+  let enableManifestTransform: EnableManifestTransform | undefined
   return {
     name: '@islands/pwa',
     config (config) {
@@ -103,7 +169,10 @@ export default function IlesPWA (options: Partial<VitePWAOptions> = {}): IlesMod
         api = plugin.api
       }
       else {
-        const pluginPWA = VitePWA(configureDefaults(config, options))
+        enableManifestTransform = () => {
+          return { enable, data }
+        }
+        const pluginPWA = VitePWA(configureDefaults(config, enableManifestTransform, options))
         api = pluginPWA.find(p => p.name === 'vite-plugin-pwa')?.api
         return {
           vite: {
@@ -117,14 +186,21 @@ export default function IlesPWA (options: Partial<VitePWAOptions> = {}): IlesMod
         if (api && !api.disabled) {
           console.info('Regenerating PWA service worker...')
           const startTime = performance.now()
-          const addRoutes = await Promise.all(pages.map((r) => {
-            return buildManifestEntry(r.path, resolve(outDir, r.outputFilename))
-          }))
-          api.extendManifestEntries((manifestEntries) => {
-            // just add the routes: the returned value will override existing entry
-            manifestEntries.push(...addRoutes)
-            return undefined
-          })
+          if (enableManifestTransform) {
+            enable = true
+            data = { outDir, pages }
+          }
+          else {
+            // TODO: we can do this only if prettyURL is enabled: the downside is the html and the logic route added twice (/about and about.html)
+            const addRoutes = await Promise.all(pages.map((r) => {
+              return buildManifestEntry(r.path, resolve(outDir, r.outputFilename))
+            }))
+            api.extendManifestEntries((manifestEntries) => {
+              // just add the routes: the returned value will override existing entry
+              manifestEntries.push(...addRoutes)
+              return undefined
+            })
+          }
           // generate the manifest.webmanifest file
           api.generateBundle()
           // regenerate the sw

--- a/packages/pwa/src/pwa.ts
+++ b/packages/pwa/src/pwa.ts
@@ -109,19 +109,6 @@ function configureDefaults (
     if (!useWorkbox.navigateFallback && prettyUrls)
       useWorkbox.navigateFallback = config.vite?.base ?? '/'
 
-    // TODO: remove this when https://github.com/antfu/vite-plugin-pwa/pull/306 released
-    if (registerType === 'autoUpdate') {
-      if (useWorkbox.clientsClaim === undefined)
-        useWorkbox.clientsClaim = true
-
-      if (useWorkbox.skipWaiting === undefined)
-        useWorkbox.skipWaiting = true
-    }
-
-    // we don't need registerSW.js if not configured
-    if (injectRegister === undefined)
-      newOptions.injectRegister = null
-
     newOptions.workbox = useWorkbox
 
     newOptions.workbox.manifestTransforms = newOptions.workbox.manifestTransforms ?? []
@@ -167,6 +154,7 @@ export default function IlesPWA (options: Partial<VitePWAOptions> = {}): IlesMod
       const plugin = config.vite?.plugins?.flat(Infinity).find(p => p.name === 'vite-plugin-pwa')
       if (plugin) {
         api = plugin.api
+        console.warn('You should configure the Vite Plugin PWA using @island/pwa module!')
       }
       else {
         enableManifestTransform = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,9 +402,9 @@ importers:
   packages/pwa:
     specifiers:
       iles: workspace:*
-      vite-plugin-pwa: ^0.12.0
+      vite-plugin-pwa: ^0.12.2
     dependencies:
-      vite-plugin-pwa: 0.12.0
+      vite-plugin-pwa: 0.12.2
     devDependencies:
       iles: link:../iles
 
@@ -740,7 +740,6 @@ packages:
       '@babel/types': 7.18.0
       '@jridgewell/gen-mapping': 0.3.1
       jsesc: 2.5.2
-    dev: false
 
   /@babel/helper-annotate-as-pure/7.15.4:
     resolution: {integrity: sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==}
@@ -753,7 +752,7 @@ packages:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.0
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.16.7:
     resolution: {integrity: sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==}
@@ -915,7 +914,6 @@ packages:
     dependencies:
       '@babel/template': 7.16.7
       '@babel/types': 7.18.0
-    dev: false
 
   /@babel/helper-get-function-arity/7.15.4:
     resolution: {integrity: sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==}
@@ -955,13 +953,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
+    dev: true
 
   /@babel/helper-member-expression-to-functions/7.17.7:
     resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.0
-    dev: false
 
   /@babel/helper-module-imports/7.15.4:
     resolution: {integrity: sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==}
@@ -981,7 +979,7 @@ packages:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.0
 
   /@babel/helper-module-transforms/7.15.8:
     resolution: {integrity: sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==}
@@ -1041,7 +1039,7 @@ packages:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.0
 
   /@babel/helper-plugin-utils/7.14.5:
     resolution: {integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==}
@@ -1051,11 +1049,11 @@ packages:
   /@babel/helper-plugin-utils/7.16.7:
     resolution: {integrity: sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-plugin-utils/7.17.12:
     resolution: {integrity: sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-remap-async-to-generator/7.16.8:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
@@ -1085,10 +1083,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-member-expression-to-functions': 7.16.7
+      '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/traverse': 7.17.0
-      '@babel/types': 7.17.0
+      '@babel/traverse': 7.18.0
+      '@babel/types': 7.18.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1254,7 +1252,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.18.0
-    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12_@babel+core@7.17.2:
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
@@ -1467,7 +1464,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.2:
@@ -1476,7 +1473,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.16.10:
@@ -1494,7 +1491,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.2:
@@ -1503,7 +1500,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.17.2:
@@ -1559,7 +1556,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.2:
@@ -1568,7 +1565,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-jsx/7.14.5:
@@ -1596,7 +1593,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.17.2:
@@ -1605,7 +1602,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.16.10:
@@ -1614,7 +1611,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.2:
@@ -1623,7 +1620,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.16.10:
@@ -1632,7 +1629,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.2:
@@ -1641,7 +1638,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.16.10:
@@ -1650,7 +1647,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.17.2:
@@ -1659,7 +1656,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.16.10:
@@ -1668,7 +1665,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.2:
@@ -1677,7 +1674,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.16.10:
@@ -1686,7 +1683,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.2:
@@ -1695,7 +1692,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.17.2:
@@ -1715,7 +1712,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.10
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: true
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.2:
@@ -1725,7 +1722,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.2
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
   /@babel/plugin-syntax-typescript/7.16.7_@babel+core@7.16.10:
@@ -1881,7 +1878,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.2
       '@babel/helper-compilation-targets': 7.17.10_@babel+core@7.17.2
-      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-function-name': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
@@ -2341,7 +2338,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/types/7.16.0:
     resolution: {integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==}
@@ -2371,7 +2367,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
-    dev: false
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2643,7 +2638,6 @@ packages:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.11
       '@jridgewell/trace-mapping': 0.3.13
-    dev: false
 
   /@jridgewell/resolve-uri/3.0.5:
     resolution: {integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==}
@@ -2652,7 +2646,6 @@ packages:
   /@jridgewell/set-array/1.1.1:
     resolution: {integrity: sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/sourcemap-codec/1.4.11:
     resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
@@ -2662,7 +2655,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
-    dev: false
 
   /@jridgewell/trace-mapping/0.3.4:
     resolution: {integrity: sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==}
@@ -3109,7 +3101,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_xujrneitbwnttbtbcvabvimcly:
+  /@rollup/plugin-babel/5.3.1_22atuqocpeaw5o6zw3apsmi63q:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3122,36 +3114,36 @@ packages:
     dependencies:
       '@babel/core': 7.17.2
       '@babel/helper-module-imports': 7.16.7
-      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
-      rollup: 2.74.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
+      rollup: 2.75.7
     dev: false
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.74.1:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.75.7:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.0
-      rollup: 2.74.1
+      rollup: 2.75.7
     dev: false
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.74.1:
+  /@rollup/plugin-replace/2.4.2_rollup@2.75.7:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
       magic-string: 0.25.7
-      rollup: 2.74.1
+      rollup: 2.75.7
     dev: false
 
-  /@rollup/pluginutils/3.1.0_rollup@2.74.1:
+  /@rollup/pluginutils/3.1.0_rollup@2.75.7:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -3160,7 +3152,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.74.1
+      rollup: 2.75.7
     dev: false
 
   /@rollup/pluginutils/4.1.2:
@@ -4549,7 +4541,7 @@ packages:
       color-name: 1.1.4
 
   /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -5589,7 +5581,7 @@ packages:
     engines: {node: '>=6'}
 
   /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
   /escape-string-regexp/2.0.0:
@@ -6251,7 +6243,7 @@ packages:
     dev: true
 
   /fs.realpath/1.0.0:
-    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -6499,7 +6491,7 @@ packages:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
 
   /has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
 
   /has-flag/4.0.0:
@@ -6811,7 +6803,7 @@ packages:
     dev: true
 
   /inflight/1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -6968,7 +6960,7 @@ packages:
     dev: false
 
   /is-module/1.0.0:
-    resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
     dev: false
 
   /is-negative-zero/2.0.2:
@@ -6986,7 +6978,7 @@ packages:
     engines: {node: '>=0.12.0'}
 
   /is-obj/1.0.1:
-    resolution: {integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=}
+    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -7031,7 +7023,7 @@ packages:
       has-tostringtag: 1.0.0
 
   /is-regexp/1.0.0:
-    resolution: {integrity: sha1-/S2INUXEa6xaYz57mgnof6LLUGk=}
+    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -7686,7 +7678,7 @@ packages:
     dev: true
 
   /jsesc/0.5.0:
-    resolution: {integrity: sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=}
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
     dev: false
 
@@ -7874,7 +7866,7 @@ packages:
     dev: true
 
   /lodash.debounce/4.0.8:
-    resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: false
 
   /lodash.get/4.4.2:
@@ -7890,7 +7882,7 @@ packages:
     dev: true
 
   /lodash.sortby/4.7.0:
-    resolution: {integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=}
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: false
 
   /lodash.truncate/4.4.2:
@@ -8889,7 +8881,7 @@ packages:
     dev: true
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
 
@@ -9065,7 +9057,7 @@ packages:
     dev: true
 
   /path-is-absolute/1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
 
   /path-key/2.0.1:
@@ -9740,14 +9732,14 @@ packages:
       glob: 7.2.0
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.74.1:
+  /rollup-plugin-terser/7.0.2_rollup@2.75.7:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
       '@babel/code-frame': 7.16.7
       jest-worker: 26.6.2
-      rollup: 2.74.1
+      rollup: 2.75.7
       serialize-javascript: 4.0.0
       terser: 5.13.1
     dev: false
@@ -9773,6 +9765,14 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+
+  /rollup/2.75.7:
+    resolution: {integrity: sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -10559,7 +10559,7 @@ packages:
     dev: true
 
   /to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
 
   /to-regex-range/5.0.1:
@@ -10591,7 +10591,7 @@ packages:
     dev: true
 
   /tr46/1.0.1:
-    resolution: {integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=}
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
       punycode: 2.1.1
     dev: false
@@ -11097,15 +11097,15 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.12.0:
-    resolution: {integrity: sha512-KYD+cnS5ExLF3T28NkfzBLZ53ehHlp+qMhHGFNh0zlVGpFHrJkL2v9wd4AMi7ZkBTffgeNatIFiv8rhCsMSxBQ==}
+  /vite-plugin-pwa/0.12.2:
+    resolution: {integrity: sha512-XK2oi1YZkoc1J8fyerNYxyh/yfb+INdrdOW/mOOD5DBLq7jVPxHQuncIhqiREbGOMlY/xMe9CSE7QZ9xIAEf7A==}
     peerDependencies:
-      vite: ^2.0.0
+      vite: ^2.0.0 || ^3.0.0-0
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11
       pretty-bytes: 6.0.0
-      rollup: 2.74.1
+      rollup: 2.75.7
       workbox-build: 6.5.3
       workbox-window: 6.5.3
     transitivePeerDependencies:
@@ -11570,9 +11570,9 @@ packages:
       '@babel/core': 7.17.2
       '@babel/preset-env': 7.18.0_@babel+core@7.17.2
       '@babel/runtime': 7.18.0
-      '@rollup/plugin-babel': 5.3.1_xujrneitbwnttbtbcvabvimcly
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.74.1
-      '@rollup/plugin-replace': 2.4.2_rollup@2.74.1
+      '@rollup/plugin-babel': 5.3.1_22atuqocpeaw5o6zw3apsmi63q
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.75.7
+      '@rollup/plugin-replace': 2.4.2_rollup@2.75.7
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.8.2
       common-tags: 1.8.2
@@ -11581,8 +11581,8 @@ packages:
       glob: 7.2.0
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.74.1
-      rollup-plugin-terser: 7.0.2_rollup@2.74.1
+      rollup: 2.75.7
+      rollup-plugin-terser: 7.0.2_rollup@2.75.7
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
@@ -11714,7 +11714,7 @@ packages:
     dev: true
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}


### PR DESCRIPTION
### Description 📖

This PR uses `workbox ManifestTransform` when pwa is configured via `@islands/pwa` plugin/module: this way we can control the sw precache manifest, adding or removing entries.

Also includes the configuration based on `prettyUrls` on `workbox.navigateFallback` entry: will use the `Vite base` or `/` when not configured.

If the pwa plugin is configured via `Vite` instead using `@islands/pwa` plugin/module, using `prettyUrls: false` will produce an error on runtime when registering the sw, since it will have the html entries twice in the sw precache manifest: you have a comment about  not adding the `addRoutes` entries on line 195 (the comment is about `prettyUrls: true`, since we'll end with the html file and also the route name, but registering the sw will work).

**TODO**: 
- the `iles.config.ts` docs file has a comment about excluding the `html` entries, we can remove it before merging this PR (the html entries on the `globPatterns` added, the new logic will remove all html entries and recalculate the revision for all routes provided in the SSG callback).
- remove the `console.log` on the pwa module, I added a few logging and so you can check the result.

### Background 📜

This was happening because I talk about it with `ElMassimo` ;)

### The Fix 🔨

By changing the `Vite PWA Plugin` options to include the `workbox ManifestTransform` to regenerate the manifest entries after `SSG` build.

### Screenshots 📷

Nopes