### PR TITLE
fix: prevent duplicated slugs for headings with the same title

### DIFF
--- a/packages/headings/src/headings.ts
+++ b/packages/headings/src/headings.ts
@@ -69,15 +69,8 @@ export const rehypePlugin: HeadingPlugin = ({ slug = generateSlug, initData = in
   vfile.data.headings = headings
 }
 
-function initCounter (ast: any) {
-  const { children } = ast as Parent
-  const counter = new Map<string, number>()
-  // add id in the counter first because when id is set it is used as slug
-  children.forEach((child: any) => {
-    const id = child.properties?.id
-    if (id) counter.set(id, 1)
-  })
-  return counter
+function initCounter () {
+  return new Map<string, number>()
 }
 
 const emojiRegex = /(?:⚡️|[\u2700-\u27BF]|(?:\uD83C[\uDDE6-\uDDFF]){2}|[\uD800-\uDBFF][\uDC00-\uDFFF])[\uFE0E\uFE0F]?(?:[\u0300-\u036F\uFE20-\uFE23\u20D0-\u20F0]|\uD83C[\uDFFB-\uDFFF])?(?:\u200D(?:[^\uD800-\uDFFF]|(?:\uD83C[\uDDE6-\uDDFF]){2}|[\uD800-\uDBFF][\uDC00-\uDFFF])[\uFE0E\uFE0F]?(?:[\u0300-\u036F\uFE20-\uFE23\u20D0-\u20F0]|\uD83C[\uDFFB-\uDFFF])?)*/g


### PR DESCRIPTION
This resolves #154.

A counter is used to track the number of duplicated titles.

To pass the counter to the slug generator, the API of `generateSlug` is modified.

ids are taken into account when generating distinct slugs, but duplicated ids are not resolved and kept as-is, because it's the user's responsibility to not set duplicated ids.

An example (test suite):

    title     id      slug
    foo       none    foo
    bar       none    bar-2
    foo       none    foo-2
    foo       bar     bar
    foo-2     none    foo-2-2
    foo-4     none    foo-4
    foo       none    foo-3
    foo       none    foo-5
    bar       none    bar-3
    foo-2     none    foo-2-3
    foo-2-2   none    foo-2-2-2
    foo       bar     bar

A consideration is that the type and initialization of `counter` limit the freedom of `HeadingOptions.slug`. Maybe we can change the parameter to a generic `T` and add `HeadingOption.init: (ast: Parent) => T` or use `any`.