### PR TITLE
fix: use createSSRApp to enable more efficient hydration

### DIFF
--- a/packages/hydration/vue.ts
+++ b/packages/hydration/vue.ts
@@ -1,9 +1,7 @@
-import { h, createApp as createClientApp, createStaticVNode, createSSRApp } from 'vue'
+import { h, createStaticVNode, createSSRApp as createVueApp } from 'vue'
 import type { DefineComponent as Component, Component as App } from 'vue'
 import type { Props, Slots } from './types'
 import { onDispose } from './hydration'
-
-const createVueApp = import.meta.env.SSR ? createSSRApp : createClientApp
 
 // Internal: Creates a Vue app and mounts it on the specified island root.
 export default function createVueIsland (component: Component, id: string, el: Element, props: Props, slots: Slots | undefined) {

--- a/packages/iles/src/client/app/composables/vueRenderer.ts
+++ b/packages/iles/src/client/app/composables/vueRenderer.ts
@@ -1,7 +1,5 @@
 import type { AppContext, Component, VNode, AsyncComponentLoader } from 'vue'
-import { h, getCurrentInstance, createApp, createSSRApp, ssrContextKey, withCtx } from 'vue'
-
-const newApp = import.meta.env.SSR ? createApp : createSSRApp
+import { h, getCurrentInstance, createSSRApp as newApp, ssrContextKey, withCtx } from 'vue'
 
 export type Nodes = undefined | VNode<any, any, any> | VNode<any, any, any>[]
 export type VueRenderable = AsyncComponentLoader | Component | Nodes | ((props?: any) => Nodes | Promise<Nodes>)

--- a/packages/iles/src/client/app/index.ts
+++ b/packages/iles/src/client/app/index.ts
@@ -1,4 +1,4 @@
-import { createApp as createClientApp, createSSRApp, ref } from 'vue'
+import { createSSRApp as newApp, ref } from 'vue'
 import { createMemoryHistory, createRouter as createVueRouter, createWebHistory } from 'vue-router'
 import { createHead } from '@vueuse/head'
 
@@ -15,8 +15,6 @@ import { resetHydrationId } from './hydration'
 import { defaultHead } from './head'
 import { resolveLayout } from './layout'
 import { resolveProps } from './props'
-
-const newApp = import.meta.env.SSR ? createSSRApp : createClientApp
 
 function createRouter (base: string | undefined, routerOptions: Partial<RouterOptions>) {
   if (base === '/') base = undefined


### PR DESCRIPTION
### Description 📖

This pull request enables more efficient hydration by using `createSSRApp`. See: https://vuejs.org/guide/scaling-up/ssr.html#client-hydration

### Background 📜

`createSSRApp` is optimized for hydration of SSR-rendered HTML. This is more efficient because if the HTML stays the same, only event listeners need to be applied but the DOM is left untouched.

### The Fix 🔨

By using `createSSRApp` we get all the benefits of efficient hydration.