### PR TITLE
Fix Typo

### DIFF
--- a/docs/src/pages/guide/index.mdx
+++ b/docs/src/pages/guide/index.mdx
@@ -34,7 +34,7 @@ Alternatively, add `iles` to your `package.json` in an existing project.
 
 The `iles` executable provides the following commands:
 
-- <kbd>iles serve</kbd>: Starts the development server
+- <kbd>iles dev</kbd>: Starts the development server
 - <kbd>iles build</kbd>: Creates a production build of the site
 - <kbd>iles preview</kbd>: Preview the site after building
 


### PR DESCRIPTION
### Description 📖

Everything else on the page says it should be "dev", not "serve", so I switch this one to match the others.