### PR TITLE
docs: deprecate `import.meta.globEager` usage

### DIFF
--- a/docs/src/pages/guide/documents.mdx
+++ b/docs/src/pages/guide/documents.mdx
@@ -8,7 +8,7 @@
 When rendering index pages, it can be convenient to import multiple pages or
 [MDX documents].
 
-Although using [`import.meta.globEager`][glob] works well, <Iles/> provides a better option.
+Although using [`import.meta.glob('./dir/*.js', { eager: true })`][glob] works well, <Iles/> provides a better option.
 
 ## `useDocuments`
 
@@ -96,8 +96,8 @@ export function usePosts () {
 }
 ```
 
-## Comparison with `import.meta.globEager`
+## Comparison with `import.meta.glob`
 
-- Significantly __faster__ than `import.meta.globEager`, as it serves a single file
+- Significantly __faster__ than `import.meta.glob('./dir/*.js', { eager: true })`, as it serves a single file
 - Can use any __aliases__ you have defined in Vite, no need to use relative paths
 - Does not reload the page when files are added or removed

--- a/docs/src/pages/guide/documents.mdx
+++ b/docs/src/pages/guide/documents.mdx
@@ -98,6 +98,6 @@ export function usePosts () {
 
 ## Comparison with `import.meta.glob`
 
-- Significantly __faster__ than `import.meta.glob('./dir/*.js', { eager: true })`, as it serves a single file
+- Significantly __faster__ than `import.meta.glob('./dir/*.mdx', { eager: true })`, as it serves a single file
 - Can use any __aliases__ you have defined in Vite, no need to use relative paths
 - Does not reload the page when files are added or removed

--- a/docs/src/pages/guide/documents.mdx
+++ b/docs/src/pages/guide/documents.mdx
@@ -8,7 +8,7 @@
 When rendering index pages, it can be convenient to import multiple pages or
 [MDX documents].
 
-Although using [`import.meta.glob('./dir/*.js', { eager: true })`][glob] works well, <Iles/> provides a better option.
+Although using [`import.meta.glob('./dir/*.mdx', { eager: true })`][glob] works well, <Iles/> provides a better option.
 
 ## `useDocuments`
 

--- a/packages/excerpt/README.md
+++ b/packages/excerpt/README.md
@@ -64,7 +64,7 @@ excerpt by passing an `excerpt: true` prop.
 <script setup>
 import Introduction from '~/pages/intro.mdx'
 
-const pages = Object.values(import.globEagerDefault('~/pages/posts/**/*.mdx'))
+const pages = useDocuments('~/pages/posts')
 </script>
 
 <template>


### PR DESCRIPTION
### Description 📖

This pull request changes the documentation to drop the deprecated `import.meta.globEager` (since Vite 3) usage. 

### Background 📜

This was happening because Vite 3 was released.

### The Fix 🔨

Not really a fix, just a documentation update.

### Screenshots 📷
