### PR TITLE
fix: do not encode file names of dynamic routes

### DIFF
--- a/packages/iles/src/node/build/utils.ts
+++ b/packages/iles/src/node/build/utils.ts
@@ -40,7 +40,8 @@ export function flattenPath (path: string) {
 // Paths ending with '/' are represented with index.html files.
 export function pathToFilename (path: string, ext = '') {
   if (path.endsWith(ext)) ext = ''
-  return `${(path.endsWith('/') ? `${path}index` : path).replace(/^\//g, '')}${ext}`
+  const decodedPath = path.split('%2F').map(decodeURIComponent).join('%2F')
+  return `${(decodedPath.endsWith('/') ? `${decodedPath}index` : decodedPath).replace(/^\//g, '')}${ext}`
 }
 
 export async function replaceAsync (str: string, regex: RegExp, asyncFn: (...groups: string[]) => Promise<string>) {

--- a/packages/iles/src/node/build/utils.ts
+++ b/packages/iles/src/node/build/utils.ts
@@ -40,7 +40,7 @@ export function flattenPath (path: string) {
 // Paths ending with '/' are represented with index.html files.
 export function pathToFilename (path: string, ext = '') {
   if (path.endsWith(ext)) ext = ''
-  const decodedPath = path.split('%2F').map(decodeURIComponent).join('%2F')
+  const decodedPath = decodeURIComponent(path)
   return `${(decodedPath.endsWith('/') ? `${decodedPath}index` : decodedPath).replace(/^\//g, '')}${ext}`
 }
 


### PR DESCRIPTION
### Description 📖

This fixes #167.

### Background 📜

#167

### The Fix 🔨

Decode the resolved path in the file name, but keep `%2F` (`/`) encoded.