### PR TITLE
fix: vendor chunk categorization

### DIFF
--- a/packages/iles/src/node/build/chunks.ts
+++ b/packages/iles/src/node/build/chunks.ts
@@ -45,8 +45,10 @@ function vendorPerFramework (
   }
 
   if (mod.isEntry) {
-    const queryIndex = id.indexOf('?')
-    const name = chunkForExtension[(queryIndex > -1 ? id.slice(0, queryIndex) : id).split('.')[1]]
+    const queryIndex = id.lastIndexOf('?')
+    const idWithoutQuery = queryIndex > -1 ? id.slice(0, queryIndex) : id
+    const extension = idWithoutQuery.slice(idWithoutQuery.lastIndexOf('.') + 1)
+    const name = chunkForExtension[extension]
     cache.set(id, name)
     return name
   }


### PR DESCRIPTION
when your product includes a . in the directory name, for example `codepunkt.de`, chunk matching for vendor modules doesn't work properly due to the module id being split at `.` and reading the second element of the resulting array, meaning to read the file extension, but instead reading an arbitrary part of the path after the `.` in the project (and/or other directory) name.

this fixes that by using `lastIndexOf` to correctly asses the extension.

### Description 📖

This pull request fixes a bug

### Background 📜

This was happening because finding out the extension when calculating the vendor chunks wasn't done properly

### The Fix 🔨

By changing to `lastIndexOf`, this works.

### Screenshots 📷
