### PR TITLE
Fix: #185 [vite] Internal server error: Missing "./dist/vue.js" export in "@islands/hydration" package, after run of `npm run dev`

### DIFF
--- a/packages/iles/src/node/alias.ts
+++ b/packages/iles/src/node/alias.ts
@@ -59,7 +59,10 @@ export function resolveAliases (root: string, userConfig: UserConfig): AliasOpti
       find: /^iles$/,
       replacement: join(DIST_CLIENT_PATH, 'index'),
     },
-    { find: /^iles\//, replacement: `${PKG_ROOT}/` },
+    {
+      find: /^iles\//,
+      replacement: `${PKG_ROOT}/`,
+    },
     // make sure it always use the same vue dependency that comes with
     // iles itself
     {
@@ -86,14 +89,6 @@ export function resolveAliases (root: string, userConfig: UserConfig): AliasOpti
         '@vue/devtools-api/lib/esm/index.js',
       ),
     },
-    {
-      find: /^@islands\/hydration$/,
-      replacement: require.resolve('@islands/hydration'),
-    },
-    ...['vue', 'vanilla', 'svelte', 'preact', 'solid'].map(name => ({
-      find: new RegExp(`^@islands/hydration/${name}$`),
-      replacement: require.resolve(`@islands/hydration/${name}`),
-    })),
   ]
 
   return aliases


### PR DESCRIPTION
Hello @ElMassimo.

### Description 📖

Fixes #185.

### Background 📜

This was happening because we are using aliases for the `@islands/hydration` package.

### The Fix 🔨

Removed aliases

### Screenshots 📷

Errors is gone:

![image](https://user-images.githubusercontent.com/2821574/185514144-1885fd76-3c82-428f-a5ff-6a94add1d1df.png)

`@islands/hydration` and `@islands/hydration/vue` is loaded:

![image](https://user-images.githubusercontent.com/2821574/185514416-c4cf098b-ad17-47ec-99ad-f4186f41f137.png)
