### PR TITLE
chore: strict glob pattern in internal scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:all": "pnpm nx run-many --target=build --all --exclude docs --exclude vue-blog",
     "lint:all": "pnpm nx run-many --target=lint --all",
-    "dev": "pnpm -r --parallel --filter ./packages/** run dev",
+    "dev": "pnpm -r --parallel --filter './packages/**' run dev",
     "docs": "npm -C docs run dev",
     "docs:build": "npm -C docs run build",
     "docs:now": "npm -C docs run now",


### PR DESCRIPTION
### Description 📖

Use the stricter glob pattern wrapped in single quotes.

### Background 📜

When people use pnpm's [`shell-emulator`](https://pnpm.io/cli/run#shell-emulator), shell will not recognize a glob pattern that is not strict enough.

Because it will be processed by the shell-emulator first.

```sh
~/Desktop/iles chore/pnpm
❯ pnpm dev

> root@ dev /Users/kecrily/Desktop/iles
> pnpm -r --parallel --filter ./packages/** run dev

 ELIFECYCLE  Command failed with exit code -7.
```
