### PR TITLE
feat(pwa): refactor pwa module

### DIFF
--- a/packages/iles/src/node/modules.ts
+++ b/packages/iles/src/node/modules.ts
@@ -3,5 +3,16 @@ export function unwrapDefault<T = any> (mod: any): T {
 }
 
 export function importModule<T = any> (path: string): Promise<T> {
+  // handle modules in Windows file system
+  if (process.platform === 'win32') {
+    // handle D:\path\to\file
+    if (path.match(/^\w:\\/))
+      return import(`file://${path.replace(/\\/g, '/')}`).then(unwrapDefault)
+
+    // handle D:/path/to/file
+    if (path.match(/^\w:\//))
+      return import(`file://${path}`).then(unwrapDefault)
+  }
+
   return import(path).then(unwrapDefault)
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/ElMassimo/iles",
   "bugs": "https://github.com/ElMassimo/iles/issues",
   "dependencies": {
-    "vite-plugin-pwa": "^0.13.1"
+    "vite-plugin-pwa": "^0.13.3"
   },
   "devDependencies": {
     "iles": "workspace:*"

--- a/packages/pwa/src/pwa.ts
+++ b/packages/pwa/src/pwa.ts
@@ -1,75 +1,33 @@
-import fs from 'fs'
-import crypto from 'crypto'
-import { resolve } from 'path'
 import { performance } from 'perf_hooks'
-import type { IlesModule, RouteToRender, UserConfig } from 'iles'
+import type { IlesModule, UserConfig } from 'iles'
 import type { VitePluginPWAAPI, VitePWAOptions } from 'vite-plugin-pwa'
-import type { ManifestEntry, ManifestTransform } from 'workbox-build'
+import type { ManifestTransform } from 'workbox-build'
 import { VitePWA } from 'vite-plugin-pwa'
 
-interface ManifestTransformData {
-  outDir: string
-  pages: RouteToRender[]
+interface PWAContext {
+  enabled: boolean
+  prettyUrls: boolean
+  base: string
 }
 
-type EnableManifestTransform = () => ManifestTransformData
+type PWAContextResolver = () => PWAContext
 
 function timeSince (start: number): string {
   const diff = performance.now() - start
   return diff < 750 ? `${Math.round(diff)}ms` : `${(diff / 1000).toFixed(1)}s`
 }
 
-function buildManifestEntry (
-  url: string,
-  path: string,
-): Promise<ManifestEntry> {
-  return new Promise((resolve, reject) => {
-    const cHash = crypto.createHash('MD5')
-    const stream = fs.createReadStream(path)
-    stream.on('error', (err) => {
-      reject(err)
-    })
-    stream.on('data', (chunk) => {
-      cHash.update(chunk)
-    })
-    stream.on('end', () => {
-      return resolve({
-        url,
-        revision: `${cHash.digest('hex')}`,
-      })
-    })
-  })
-}
-
-async function buildManifestEntryTransform (
-  ssgUrl: string,
-  path: string,
-): Promise<ManifestEntry & { size: number }> {
-  const [size, { url, revision }] = await Promise.all([
-    new Promise<number>((resolve, reject) => {
-      fs.lstat(path, (err, stats) => {
-        if (err)
-          reject(err)
-        else
-          resolve(stats.size)
-      })
-    }),
-    buildManifestEntry(ssgUrl, path),
-  ])
-  return { url, revision, size }
-}
-
-function createManifestTransform (enableManifestTransform: EnableManifestTransform): ManifestTransform {
+function createManifestTransform (resolve: PWAContextResolver): ManifestTransform {
   return async (entries) => {
-    const data = enableManifestTransform()
-    if (data) {
-      const { outDir, pages } = data
-      const manifest = entries.filter(e => !e.url.endsWith('.html'))
-      const addRoutes = await Promise.all(pages.map((r) => {
-        return buildManifestEntryTransform(r.path, resolve(outDir, r.outputFilename))
-      }))
-      manifest.push(...addRoutes)
-      return { manifest }
+    const { base, enabled, prettyUrls } = resolve()
+    // entries already in the precache manifest, we only need to change the mapping when prettyUrls is enabled
+    if (enabled && prettyUrls) {
+      entries.filter(e => e.url.endsWith('.html')).forEach((e) => {
+        if (e.url === 'index.html')
+          e.url = base
+        else
+          e.url = e.url.replace(/\.html$/, '')
+      })
     }
 
     return { manifest: entries }
@@ -78,7 +36,7 @@ function createManifestTransform (enableManifestTransform: EnableManifestTransfo
 
 function configureDefaults (
   config: UserConfig,
-  enableManifestTransform: EnableManifestTransform,
+  resolve: PWAContextResolver,
   options: Partial<VitePWAOptions> = {},
 ): Partial<VitePWAOptions> {
   const {
@@ -98,21 +56,33 @@ function configureDefaults (
       registerType,
       injectRegister,
     }
-    const prettyUrls = config.prettyUrls ?? true
-    if (!useWorkbox.navigateFallback && prettyUrls)
-      useWorkbox.navigateFallback = config.vite?.base ?? '/'
 
     newOptions.workbox = useWorkbox
 
     newOptions.workbox.manifestTransforms = newOptions.workbox.manifestTransforms ?? []
-    newOptions.workbox.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+    newOptions.workbox.manifestTransforms.push(createManifestTransform(resolve))
+
+    // configure 404 navigation fallback only if not already configured
+    if (!useWorkbox.navigateFallback) {
+      newOptions.integration = {
+        configureOptions (_, pwaOptions) {
+          // pwaOptions is the same as newOptions: just adding this, linter complains
+          pwaOptions.workbox = pwaOptions.workbox ?? {}
+          const { base, prettyUrls } = resolve()
+          if (prettyUrls)
+            pwaOptions.workbox.navigateFallback = `${base}404`
+          else
+            pwaOptions.workbox.navigateFallback = `${base}404.html`
+        },
+      }
+    }
 
     return newOptions
   }
 
   options.injectManifest = options.injectManifest ?? {}
   options.injectManifest.manifestTransforms = injectManifest.manifestTransforms ?? []
-  options.injectManifest.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+  options.injectManifest.manifestTransforms.push(createManifestTransform(resolve))
 
   return options
 }
@@ -125,35 +95,40 @@ function configureDefaults (
  */
 export default function IlesPWA (options: Partial<VitePWAOptions> = {}): IlesModule {
   let api: VitePluginPWAAPI | undefined
-  let data: ManifestTransformData | undefined
-  const enableManifestTransform: EnableManifestTransform = () => {
-    return data!
+  const ctx: PWAContext = {
+    enabled: false,
+    prettyUrls: true,
+    base: '/',
+  }
+  const resolver: PWAContextResolver = () => {
+    return ctx
   }
   return {
     name: '@islands/pwa',
     config (config) {
       const plugin = config.vite?.plugins?.flat(Infinity).find(p => p.name === 'vite-plugin-pwa')
-      if (plugin) {
+      if (plugin)
         throw new Error('Remove the vite-plugin-pwa plugin from Vite plugins entry in iles config file, configure it via @islands/pwa plugin')
-      }
-      else {
-        const pluginPWA = VitePWA(configureDefaults(config, enableManifestTransform, options))
-        api = pluginPWA.find(p => p.name === 'vite-plugin-pwa')?.api
-        return {
-          vite: {
-            plugins: [pluginPWA],
-          },
-        }
+
+      const pluginPWA = VitePWA(configureDefaults(config, resolver, options))
+      api = pluginPWA.find(p => p.name === 'vite-plugin-pwa')?.api
+      return {
+        vite: {
+          plugins: [pluginPWA],
+        },
       }
     },
+    configResolved ({ base, prettyUrls }) {
+      // the hook will be called before the pwa plugin integration hook
+      ctx.base = base
+      ctx.prettyUrls = prettyUrls
+    },
     ssg: {
-      async onSiteRendered ({ pages, config: { outDir } }) {
+      async onSiteRendered () {
         if (api && !api.disabled) {
           console.info('Regenerating PWA service worker...')
           const startTime = performance.now()
-          data = { outDir, pages }
-          // generate the manifest.webmanifest file
-          api.generateBundle()
+          ctx.enabled = true
           // regenerate the sw
           await api.generateSW()
           console.info(`\n√  PWA done in ${timeSince(startTime)}\n`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,9 +404,9 @@ importers:
   packages/pwa:
     specifiers:
       iles: workspace:*
-      vite-plugin-pwa: ^0.13.1
+      vite-plugin-pwa: ^0.13.3
     dependencies:
-      vite-plugin-pwa: 0.13.1
+      vite-plugin-pwa: 0.13.3
     devDependencies:
       iles: link:../iles
 
@@ -607,28 +607,22 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.17.12
+    dev: true
 
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: true
 
   /@babel/compat-data/7.15.0:
     resolution: {integrity: sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/compat-data/7.18.5:
-    resolution: {integrity: sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/compat-data/7.19.4:
     resolution: {integrity: sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/core/7.15.8:
     resolution: {integrity: sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==}
@@ -653,29 +647,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core/7.18.5:
-    resolution: {integrity: sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.2
-      '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.5
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helpers': 7.18.2
-      '@babel/parser': 7.18.5
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.5
-      '@babel/types': 7.18.4
-      convert-source-map: 1.8.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/core/7.19.3:
     resolution: {integrity: sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==}
     engines: {node: '>=6.9.0'}
@@ -697,7 +668,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/eslint-parser/7.18.2_mmbyq476xpa6tuwz6732ekfpz4:
     resolution: {integrity: sha512-oFQYkE8SuH14+uR51JVAmdqwKYXGRjEXx7s+WiagVjqQ+HPE+nnwyF2qlVG8evUsUHmPcA+6YXMEDbIhEyQc5A==}
@@ -722,15 +692,6 @@ packages:
       source-map: 0.5.7
     dev: true
 
-  /@babel/generator/7.17.0:
-    resolution: {integrity: sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: false
-
   /@babel/generator/7.18.2:
     resolution: {integrity: sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==}
     engines: {node: '>=6.9.0'}
@@ -738,6 +699,7 @@ packages:
       '@babel/types': 7.18.4
       '@jridgewell/gen-mapping': 0.3.1
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator/7.19.5:
     resolution: {integrity: sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==}
@@ -746,7 +708,6 @@ packages:
       '@babel/types': 7.19.4
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-annotate-as-pure/7.15.4:
     resolution: {integrity: sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==}
@@ -754,13 +715,6 @@ packages:
     dependencies:
       '@babel/types': 7.16.0
     dev: true
-
-  /@babel/helper-annotate-as-pure/7.16.7:
-    resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -773,7 +727,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
-      '@babel/types': 7.18.7
+      '@babel/types': 7.19.4
     dev: false
 
   /@babel/helper-compilation-targets/7.15.4_@babel+core@7.15.8:
@@ -789,19 +743,6 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-compilation-targets/7.18.2_@babel+core@7.18.5:
-    resolution: {integrity: sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.18.5
-      '@babel/core': 7.18.5
-      '@babel/helper-validator-option': 7.16.7
-      browserslist: 4.21.0
-      semver: 6.3.0
-    dev: false
-
   /@babel/helper-compilation-targets/7.19.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==}
     engines: {node: '>=6.9.0'}
@@ -813,25 +754,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
-    dev: true
-
-  /@babel/helper-create-class-features-plugin/7.18.0_@babel+core@7.18.5:
-    resolution: {integrity: sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-annotate-as-pure': 7.16.7
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-member-expression-to-functions': 7.17.7
-      '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/helper-replace-supers': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -849,29 +771,28 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.17.12_@babel+core@7.18.5:
+  /@babel/helper-create-regexp-features-plugin/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-b2aZrV4zvutr9AIa6/gA3wsZKRwTKYoDxYiFKcESS3Ug2GTXzwBEvMuuFLhCQpEnRXs1zng4ISAXSUxxKBIcxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.0.1
     dev: false
 
-  /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.18.5:
+  /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.19.3
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/traverse': 7.18.5
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/traverse': 7.19.4
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
@@ -880,28 +801,15 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-environment-visitor/7.16.7:
-    resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
-
-  /@babel/helper-environment-visitor/7.18.2:
-    resolution: {integrity: sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-explode-assignable-expression/7.16.7:
     resolution: {integrity: sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.19.4
     dev: false
 
   /@babel/helper-function-name/7.15.4:
@@ -913,30 +821,12 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-function-name/7.16.7:
-    resolution: {integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-get-function-arity': 7.16.7
-      '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
-    dev: false
-
-  /@babel/helper-function-name/7.17.9:
-    resolution: {integrity: sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.16.7
-      '@babel/types': 7.18.4
-    dev: false
-
   /@babel/helper-function-name/7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-get-function-arity/7.15.4:
     resolution: {integrity: sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==}
@@ -945,13 +835,6 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-get-function-arity/7.16.7:
-    resolution: {integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
-
   /@babel/helper-hoist-variables/7.15.4:
     resolution: {integrity: sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==}
     engines: {node: '>=6.9.0'}
@@ -959,19 +842,11 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-hoist-variables/7.16.7:
-    resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.4
-    dev: false
-
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-member-expression-to-functions/7.15.4:
     resolution: {integrity: sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==}
@@ -980,26 +855,11 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-member-expression-to-functions/7.16.7:
-    resolution: {integrity: sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
-
-  /@babel/helper-member-expression-to-functions/7.17.7:
-    resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.0
-    dev: false
-
   /@babel/helper-member-expression-to-functions/7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-module-imports/7.15.4:
     resolution: {integrity: sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==}
@@ -1014,13 +874,6 @@ packages:
     dependencies:
       '@babel/types': 7.19.4
     dev: true
-
-  /@babel/helper-module-imports/7.16.7:
-    resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.4
-    dev: false
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -1044,22 +897,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-module-transforms/7.18.0:
-    resolution: {integrity: sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.2
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-simple-access': 7.18.2
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/helper-validator-identifier': 7.16.7
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.5
-      '@babel/types': 7.18.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helper-module-transforms/7.19.0:
     resolution: {integrity: sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==}
     engines: {node: '>=6.9.0'}
@@ -1074,7 +911,6 @@ packages:
       '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-optimise-call-expression/7.15.4:
     resolution: {integrity: sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==}
@@ -1083,19 +919,11 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.16.7:
-    resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
-
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-plugin-utils/7.14.5:
     resolution: {integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==}
@@ -1109,11 +937,11 @@ packages:
   /@babel/helper-plugin-utils/7.18.6:
     resolution: {integrity: sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-plugin-utils/7.19.0:
     resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-remap-async-to-generator/7.16.8:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
@@ -1121,7 +949,7 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-wrap-function': 7.16.8
-      '@babel/types': 7.18.7
+      '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1138,19 +966,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-replace-supers/7.16.7:
-    resolution: {integrity: sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-member-expression-to-functions': 7.16.7
-      '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/traverse': 7.17.0
-      '@babel/types': 7.17.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helper-replace-supers/7.19.1:
     resolution: {integrity: sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==}
     engines: {node: '>=6.9.0'}
@@ -1162,7 +977,6 @@ packages:
       '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-simple-access/7.15.4:
     resolution: {integrity: sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==}
@@ -1171,25 +985,17 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-simple-access/7.18.2:
-    resolution: {integrity: sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.4
-    dev: false
-
   /@babel/helper-simple-access/7.19.4:
     resolution: {integrity: sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers/7.16.0:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.19.4
     dev: false
 
   /@babel/helper-split-export-declaration/7.15.4:
@@ -1199,24 +1005,15 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-split-export-declaration/7.16.7:
-    resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.4
-    dev: false
-
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier/7.15.7:
     resolution: {integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==}
@@ -1234,31 +1031,24 @@ packages:
   /@babel/helper-validator-identifier/7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option/7.14.5:
     resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-option/7.16.7:
-    resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/helper-validator-option/7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-wrap-function/7.16.8:
     resolution: {integrity: sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.17.9
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.5
-      '@babel/types': 7.18.7
+      '@babel/helper-function-name': 7.19.0
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.19.4
+      '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1274,17 +1064,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helpers/7.18.2:
-    resolution: {integrity: sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.5
-      '@babel/types': 7.18.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helpers/7.19.4:
     resolution: {integrity: sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==}
     engines: {node: '>=6.9.0'}
@@ -1294,7 +1073,6 @@ packages:
       '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight/7.14.5:
     resolution: {integrity: sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==}
@@ -1312,6 +1090,7 @@ packages:
       '@babel/helper-validator-identifier': 7.16.7
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -1320,7 +1099,6 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: true
 
   /@babel/parser/7.16.2:
     resolution: {integrity: sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==}
@@ -1338,14 +1116,6 @@ packages:
       '@babel/types': 7.18.4
     dev: true
 
-  /@babel/parser/7.17.0:
-    resolution: {integrity: sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: false
-
   /@babel/parser/7.18.5:
     resolution: {integrity: sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==}
     engines: {node: '>=6.0.0'}
@@ -1359,220 +1129,210 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-/vt0hpIw0x4b6BLKUkwlvEoiGZYYLNZ96CzyHYPbtG2jZGz6LBe7/V+drYrc/d+ovrF9NBi0pmtvmNb/FsWtRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
-      '@babel/plugin-proposal-optional-chaining': 7.17.12_@babel+core@7.18.5
+      '@babel/plugin-proposal-optional-chaining': 7.17.12_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-async-generator-functions/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-async-generator-functions/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-RWVvqD1ooLKP6IqWTA5GyFVX2isGEgC5iFxKzfYOIy/QEFdxYyCybBDtIGjipHpb9bDWHzcqGqFakf+mVmBTdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-properties/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-class-properties/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-static-block/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-proposal-class-static-block/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-t+8LsRMMDE74c6sV7KShIw13sqbqd58tlqNrsWoWBTIMw7SVQ0cZ905wLNS/FBCy/3PyooRHLFFlfrUNyyz5lA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-export-namespace-from/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-export-namespace-from/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-j7Ye5EWdwoXOpRmo5QmRyHPsDIe6+u70ZYZrd7uz+ebPYFKfRcLcNu3Ro0vOlJ5zuv8rU7xa+GttNiRzX56snQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-json-strings/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-json-strings/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-rKJ+rKBoXwLnIn7n6o6fulViHMrOThz99ybH+hKHcOZbnN14VuMnH9fo2eHE69C8pO4uX1Q7t2HYYIDmv8VYkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-logical-assignment-operators/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-EqFo2s1Z5yy+JeJu7SFfbIUtToJTVlC61/C7WLKDntSw4Sz6JNAIfL7zQ74VvirxpjB5kz/kIx0gCcb+5OEo2Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-ws/g3FSGVzv+VH86+QvgtuJL/kR67xaEIF2x0iPqdDfYW6ra6JF3lKVBkWynRLcNtIC1oCTfDRVxmm2mKzy+ag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-object-rest-spread/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-proposal-object-rest-spread/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-nbTv371eTrFabDfHLElkn9oyf9VG+VKK6WMzhY2o4eHKaG19BToD9947zzGMO6I/Irstx9d8CwX6njPNIAR/yw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.5
-      '@babel/core': 7.18.5
-      '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-transform-parameters': 7.17.12_@babel+core@7.18.5
+      '@babel/compat-data': 7.19.4
+      '@babel/core': 7.19.3
+      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-transform-parameters': 7.17.12_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-optional-chaining/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-7wigcOs/Z4YWlK7xxjkvaIw84vGhDv/P1dFGQap0nHkc8gFKY/r+hXc8Qzf5k1gY7CvGIcHqAnOagVKJJ1wVOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.3
     dev: false
 
-  /@babel/plugin-proposal-private-methods/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-private-methods/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-SllXoxo19HmxhDWm3luPz+cPhtoTSKLJE9PXshsfrOzBqs60QP0r8OaJItrPhAj0d7mZMnNF0Y1UUggCDgMz1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-private-property-in-object/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-/6BtVi57CJfrtDNKfK5b66ydK2J5pXUKBKSPD2G1whamMuEnZWgoOIfO8Vf9F/DoD4izBLD/Au4NMQfruzzykg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.5
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-unicode-property-regex/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-proposal-unicode-property-regex/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-Wb9qLjXf3ZazqXA7IvI7ozqRIXIGPtSo+L5coFmEkhTQK18ao4UDDD0zdTGAarmbLj2urpRwrc6893cu5Bfh0A==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-    dev: false
-
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.5:
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/core': 7.19.3
+      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.19.3:
@@ -1582,7 +1342,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -1593,15 +1352,6 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.5:
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
-
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.19.3:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
@@ -1609,44 +1359,43 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.18.5:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.19.3:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.18.5:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.18.5:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-syntax-import-assertions/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-syntax-import-assertions/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-n/loy2zkq9ZEM8tEOwON9wTQSTNDTDEz6NujPtJGLU7qObzT1N4c4YZZf8E6ATB2AjNQg/Ib2AIpO03EZaCehw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.19.3:
@@ -1658,15 +1407,6 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.5:
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
-
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
@@ -1674,7 +1414,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-jsx/7.14.5:
     resolution: {integrity: sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==}
@@ -1704,15 +1443,6 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.5:
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
-
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.19.3:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1720,16 +1450,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.5:
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1738,16 +1458,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.5:
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.19.3:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1756,16 +1466,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.5:
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1774,16 +1474,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.5:
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1792,16 +1482,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.5:
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: false
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1810,26 +1490,15 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.18.5:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.19.3:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-    dev: false
-
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.5:
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.19.3:
@@ -1840,7 +1509,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.19.3:
     resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
@@ -1852,273 +1520,273 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-arrow-functions/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-PHln3CNi/49V+mza4xMwrg+WGYevSF1oaiXaC2EQfdp4HWlSjRsrDXWJiQBKpP7749u6vQ9mcry2uuFOv5CXvA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-async-to-generator/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-async-to-generator/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-J8dbrWIOO3orDzir57NRsjg4uxucvhby0L/KZuGsWDj0g7twWK3g7JhJhOrXtuXiw8MeiSdJ3E0OW9H8LYEzLQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-block-scoping/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-block-scoping/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-jw8XW/B1i7Lqwqj2CbrViPcZijSxfguBWZP2aN59NHgxUyO/OcO1mfdCxH13QhN5LbWhPkX+f+brKGhZTiqtZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-classes/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-classes/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-cvO7lc7pZat6BsvH6l/EGaI8zpl8paICaoGk+7x7guvtfak/TbIf66nYmJOH13EuG0H+Xx3M+9LQDtSvZFKXKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.2
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-replace-supers': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-computed-properties/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-computed-properties/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-a7XINeplB5cQUWMg1E/GI1tFz3LfK021IjV1rj1ypE+R7jHm+pIHmHl25VNkZxtx9uuYp7ThGk8fur1HHG7PgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-destructuring/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-destructuring/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-Mo69klS79z6KEfrLg/1WkmVnB8javh75HX4pi2btjvlIoasuxilEyjtsQW6XPrubNd7AQy0MMaNIaQE4e7+PQw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-duplicate-keys/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-EA5eYFUG6xeerdabina/xIoB95jJ17mAkR8ivx6ZSu9frKShBjpOGZPn511MTDTkiCO+zXnzNczvUM69YSf3Zw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-for-of/7.18.1_@babel+core@7.18.5:
+  /@babel/plugin-transform-for-of/7.18.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-+TTB5XwvJ5hZbO8xvl2H4XaMDOAK57zF4miuC9qQJgysPNEAZZ9Z69rdF5LJkozGdZrjBIUAIyKUWRMmebI7vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.5
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.19.3
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-literals/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-literals/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-8iRkvaTjJciWycPIZ9k9duu663FT7VrBdNqNgxnVXEFwOIp55JWcZd23VBRySYbnS3PwQ3rGiabJBBBGj5APmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-modules-amd/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-modules-amd/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-h8FjOlYmdZwl7Xm2Ug4iX2j7Qy63NANI+NQVWQzv6r25fqgg7k2dZl03p95kvqNclglHs4FZ+isv4p1uXMA+QA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-commonjs/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-modules-commonjs/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-cCeR0VZWtfxWS4YueAK2qtHtBPJRSaJcMlbS8jhSIm/A3E2Kpro4W1Dn4cqJtp59dtWfXjQwK7SPKF8ghs7rlw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-simple-access': 7.18.2
+      '@babel/core': 7.19.3
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-simple-access': 7.19.4
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-modules-systemjs/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-vwKpxdHnlM5tIrRt/eA0bzfbi7gUBLN08vLu38np1nZevlPySRe6yvuATJB5F/WPJ+ur4OXwpVYq9+BsxqAQuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-validator-identifier': 7.19.1
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-umd/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-modules-umd/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-d/zZ8I3BWli1tmROLxXLc9A6YXvGK8egMxHp+E/rRwMh1Kip0AP77VwZae3snEJ33iiWwvNv2+UIIhfalqhzZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-vWoWFM5CKaTeHrdUJ/3SIOTRV+MBVGybOC9mhJkaprGNt5demMymDW24yC74avb915/mIRe3TgNb/d8idvnCRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-new-target/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-new-target/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-CaOtzk2fDYisbjAD4Sd1MTKGVIpRtx9bWLyj24Y/k6p4s4gQ3CqDGJauFJxt8M/LEx003d0i3klVqnN73qvK3w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-replace-supers': 7.16.7
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-parameters/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-parameters/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-6qW4rWo1cyCdq1FkYri7AHpauchbGLXpdwnYsfxFb+KtddHENfsY5JZb35xUwkK5opOLcJ3BNd2l7PhRYGlwIA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
   /@babel/plugin-transform-react-jsx-development/7.18.6:
@@ -2156,76 +1824,76 @@ packages:
       '@babel/types': 7.19.4
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.18.0_@babel+core@7.18.5:
+  /@babel/plugin-transform-regenerator/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-C8YdRw9uzx25HSIzwA7EM7YP0FhCe5wNvJbZzjVNHHPGVcDJ3Aie+qGYYdS1oVQgn+B3eAIJbWFLrJ4Jipv7nw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
       regenerator-transform: 0.15.0
     dev: false
 
-  /@babel/plugin-transform-reserved-words/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-reserved-words/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-1KYqwbJV3Co03NIi14uEHW8P50Md6KqFgt0FfpHdK6oyAHQVTosgPuPSiWud1HX0oYJ1hGRRlk0fP87jFpqXZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-spread/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-spread/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-9pgmuQAtFi3lpNUstvG9nGfk9DkrdmWNp9KeKPFmuZCpEnxRzYlS8JgwPjYj+1AWDOSvoGN0H30p1cBOmT/Svg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
     dev: false
 
-  /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-template-literals/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-template-literals/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-kAKJ7DX1dSRa2s7WN1xUAuaQmkTpN+uig4wCKWivVXIObqGbVTUlSavHyfI2iZvz89GFAMGm9p2DBJ4Y1Tp0hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol/7.17.12_@babel+core@7.18.5:
+  /@babel/plugin-transform-typeof-symbol/7.17.12_@babel+core@7.19.3:
     resolution: {integrity: sha512-Q8y+Jp7ZdtSPXCThB6zjQ74N3lj0f6TDh1Hnf5B+sYlzQ8i5Pjp8gW0My79iekSpT4WnI06blqP6DT0OmaXXmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
   /@babel/plugin-transform-typescript/7.19.3_@babel+core@7.19.3:
@@ -2242,123 +1910,123 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.18.5:
+  /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.19.3:
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/core': 7.19.3
+      '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
     dev: false
 
-  /@babel/preset-env/7.18.0_@babel+core@7.18.5:
+  /@babel/preset-env/7.18.0_@babel+core@7.19.3:
     resolution: {integrity: sha512-cP74OMs7ECLPeG1reiCQ/D/ypyOxgfm8uR6HRYV23vTJ7Lu1nbgj9DQDo/vH59gnn7GOAwtTDPPYV4aXzsMKHA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.5
-      '@babel/core': 7.18.5
-      '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-validator-option': 7.16.7
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-async-generator-functions': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-class-properties': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-class-static-block': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-proposal-dynamic-import': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-proposal-export-namespace-from': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-json-strings': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-logical-assignment-operators': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-numeric-separator': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-proposal-object-rest-spread': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-proposal-optional-chaining': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-private-methods': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-private-property-in-object': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-proposal-unicode-property-regex': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.5
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.18.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-import-assertions': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.5
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.5
-      '@babel/plugin-transform-arrow-functions': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-async-to-generator': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-block-scoped-functions': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-block-scoping': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-classes': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-computed-properties': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-destructuring': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-duplicate-keys': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-exponentiation-operator': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-for-of': 7.18.1_@babel+core@7.18.5
-      '@babel/plugin-transform-function-name': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-literals': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-member-expression-literals': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-modules-amd': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-modules-commonjs': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-modules-systemjs': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-modules-umd': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-new-target': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-object-super': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-parameters': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-property-literals': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-regenerator': 7.18.0_@babel+core@7.18.5
-      '@babel/plugin-transform-reserved-words': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-spread': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-sticky-regex': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-template-literals': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-typeof-symbol': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.18.5
-      '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.18.5
-      '@babel/preset-modules': 0.1.5_@babel+core@7.18.5
-      '@babel/types': 7.18.7
-      babel-plugin-polyfill-corejs2: 0.3.1_@babel+core@7.18.5
-      babel-plugin-polyfill-corejs3: 0.5.2_@babel+core@7.18.5
-      babel-plugin-polyfill-regenerator: 0.3.1_@babel+core@7.18.5
+      '@babel/compat-data': 7.19.4
+      '@babel/core': 7.19.3
+      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-async-generator-functions': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-class-properties': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-class-static-block': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-proposal-dynamic-import': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-proposal-export-namespace-from': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-json-strings': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-logical-assignment-operators': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-numeric-separator': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-proposal-object-rest-spread': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-proposal-optional-chaining': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-private-methods': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-private-property-in-object': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-proposal-unicode-property-regex': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.19.3
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.3
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-import-assertions': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.3
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.19.3
+      '@babel/plugin-transform-arrow-functions': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-async-to-generator': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-block-scoped-functions': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-block-scoping': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-classes': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-computed-properties': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-destructuring': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-duplicate-keys': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-exponentiation-operator': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-for-of': 7.18.1_@babel+core@7.19.3
+      '@babel/plugin-transform-function-name': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-literals': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-member-expression-literals': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-modules-amd': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-modules-commonjs': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-modules-systemjs': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-modules-umd': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-new-target': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-object-super': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-parameters': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-property-literals': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-regenerator': 7.18.0_@babel+core@7.19.3
+      '@babel/plugin-transform-reserved-words': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-spread': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-sticky-regex': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-template-literals': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-typeof-symbol': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.19.3
+      '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.19.3
+      '@babel/preset-modules': 0.1.5_@babel+core@7.19.3
+      '@babel/types': 7.19.4
+      babel-plugin-polyfill-corejs2: 0.3.1_@babel+core@7.19.3
+      babel-plugin-polyfill-corejs3: 0.5.2_@babel+core@7.19.3
+      babel-plugin-polyfill-regenerator: 0.3.1_@babel+core@7.19.3
       core-js-compat: 3.22.7
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.18.5:
+  /@babel/preset-modules/0.1.5_@babel+core@7.19.3:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-proposal-unicode-property-regex': 7.17.12_@babel+core@7.18.5
-      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.18.5
-      '@babel/types': 7.18.7
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.17.12_@babel+core@7.19.3
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.19.3
+      '@babel/types': 7.19.4
       esutils: 2.0.3
     dev: false
 
@@ -2392,15 +2060,6 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/template/7.16.7:
-    resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.18.5
-      '@babel/types': 7.18.4
-    dev: false
-
   /@babel/template/7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
     engines: {node: '>=6.9.0'}
@@ -2408,7 +2067,6 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.19.4
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/traverse/7.15.4:
     resolution: {integrity: sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==}
@@ -2427,42 +2085,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/traverse/7.17.0:
-    resolution: {integrity: sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.0
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.16.7
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.17.0
-      '@babel/types': 7.17.0
-      debug: 4.3.3
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/traverse/7.18.5:
-    resolution: {integrity: sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.2
-      '@babel/helper-environment-visitor': 7.18.2
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.18.5
-      '@babel/types': 7.18.4
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/traverse/7.19.4:
     resolution: {integrity: sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==}
     engines: {node: '>=6.9.0'}
@@ -2479,7 +2101,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types/7.16.0:
     resolution: {integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==}
@@ -2495,14 +2116,7 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
-
-  /@babel/types/7.18.0:
-    resolution: {integrity: sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
-    dev: false
+    dev: true
 
   /@babel/types/7.18.4:
     resolution: {integrity: sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==}
@@ -2525,7 +2139,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2827,6 +2440,7 @@ packages:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.13
       '@jridgewell/trace-mapping': 0.3.13
+    dev: true
 
   /@jridgewell/gen-mapping/0.3.2:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
@@ -2835,7 +2449,6 @@ packages:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.13
       '@jridgewell/trace-mapping': 0.3.13
-    dev: true
 
   /@jridgewell/resolve-uri/3.0.7:
     resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
@@ -3331,7 +2944,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_sgzqfpkvn2bvtmovwhjoctziim:
+  /@rollup/plugin-babel/5.3.1_vy4anxjpv2s44kyfi2kxqu576u:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3342,7 +2955,7 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.5
+      '@babel/core': 7.19.3
       '@babel/helper-module-imports': 7.18.6
       '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       rollup: 2.79.1
@@ -3365,6 +2978,16 @@ packages:
 
   /@rollup/plugin-replace/2.4.2_rollup@2.79.1:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      magic-string: 0.25.7
+      rollup: 2.79.1
+    dev: false
+
+  /@rollup/plugin-replace/4.0.0_rollup@2.79.1:
+    resolution: {integrity: sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
@@ -4565,38 +4188,38 @@ packages:
       html-entities: 2.3.2
     dev: true
 
-  /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.18.5:
+  /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.5
-      '@babel/core': 7.18.5
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.18.5
+      '@babel/compat-data': 7.19.4
+      '@babel/core': 7.19.3
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.19.3
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3/0.5.2_@babel+core@7.18.5:
+  /babel-plugin-polyfill-corejs3/0.5.2_@babel+core@7.19.3:
     resolution: {integrity: sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.19.3
       core-js-compat: 3.22.7
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.18.5:
+  /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.5
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4723,17 +4346,6 @@ packages:
       picocolors: 1.0.0
     dev: true
 
-  /browserslist/4.21.0:
-    resolution: {integrity: sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001358
-      electron-to-chromium: 1.4.166
-      node-releases: 2.0.5
-      update-browserslist-db: 1.0.3_browserslist@4.21.0
-    dev: false
-
   /browserslist/4.21.4:
     resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -4743,7 +4355,6 @@ packages:
       electron-to-chromium: 1.4.283
       node-releases: 2.0.6
       update-browserslist-db: 1.0.10_browserslist@4.21.4
-    dev: true
 
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -4824,13 +4435,8 @@ packages:
     resolution: {integrity: sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==}
     dev: true
 
-  /caniuse-lite/1.0.30001358:
-    resolution: {integrity: sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==}
-    dev: false
-
   /caniuse-lite/1.0.30001420:
     resolution: {integrity: sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==}
-    dev: true
 
   /ccount/2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -5299,7 +4905,7 @@ packages:
   /core-js-compat/3.22.7:
     resolution: {integrity: sha512-uI9DAQKKiiE/mclIC5g4AjRpio27g+VMRhe6rQoz+q4Wm4L6A/fJhiLtBw+sfOpDG9wZ3O0pxIw7GbfOlBgjOA==}
     dependencies:
-      browserslist: 4.21.0
+      browserslist: 4.21.4
       semver: 7.0.0
     dev: false
 
@@ -5669,17 +5275,12 @@ packages:
     resolution: {integrity: sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA==}
     dev: true
 
-  /electron-to-chromium/1.4.166:
-    resolution: {integrity: sha512-ZPLdq3kcATkD6dwne5M4SgJBHw21t90BqTGzf3AceJwj3cE/ICv6jyDwHYyJoF4JNuXM3pzRxlaRmpO7pdwmcg==}
-    dev: false
-
   /electron-to-chromium/1.4.28:
     resolution: {integrity: sha512-Gzbf0wUtKfyPaqf0Plz+Ctinf9eQIzxEqBHwSvbGfeOm9GMNdLxyu1dNiCUfM+x6r4BE0xUJNh3Nmg9gfAtTmg==}
     dev: true
 
   /electron-to-chromium/1.4.283:
     resolution: {integrity: sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==}
-    dev: true
 
   /emittery/0.8.1:
     resolution: {integrity: sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==}
@@ -9452,13 +9053,8 @@ packages:
     resolution: {integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==}
     dev: true
 
-  /node-releases/2.0.5:
-    resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==}
-    dev: false
-
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
-    dev: true
 
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -10542,7 +10138,7 @@ packages:
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
@@ -10816,6 +10412,7 @@ packages:
   /source-map/0.5.7:
     resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -11842,18 +11439,6 @@ packages:
       browserslist: 4.21.4
       escalade: 3.1.1
       picocolors: 1.0.0
-    dev: true
-
-  /update-browserslist-db/1.0.3_browserslist@4.21.0:
-    resolution: {integrity: sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.0
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: false
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -11961,11 +11546,12 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.13.1:
-    resolution: {integrity: sha512-NR3dIa+o2hzlzo4lF4Gu0cYvoMjSw2DdRc6Epw1yjmCqWaGuN86WK9JqZie4arNlE1ZuWT3CLiMdiX5wcmmUmg==}
+  /vite-plugin-pwa/0.13.3:
+    resolution: {integrity: sha512-cjWXpZ7slAY14OKz7M8XdgTIi9wjf6OD6NkhiMAc+ogxnbUrecUwLdRtfGPCPsN2ftut5gaN1jTghb11p6IQAA==}
     peerDependencies:
       vite: ^3.1.0
     dependencies:
+      '@rollup/plugin-replace': 4.0.0_rollup@2.79.1
       debug: 4.3.4
       fast-glob: 3.2.11
       pretty-bytes: 6.0.0
@@ -12488,10 +12074,10 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@apideck/better-ajv-errors': 0.3.3_ajv@8.11.0
-      '@babel/core': 7.18.5
-      '@babel/preset-env': 7.18.0_@babel+core@7.18.5
+      '@babel/core': 7.19.3
+      '@babel/preset-env': 7.18.0_@babel+core@7.19.3
       '@babel/runtime': 7.18.0
-      '@rollup/plugin-babel': 5.3.1_sgzqfpkvn2bvtmovwhjoctziim
+      '@rollup/plugin-babel': 5.3.1_vy4anxjpv2s44kyfi2kxqu576u
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
       '@rollup/plugin-replace': 2.4.2_rollup@2.79.1
       '@surma/rollup-plugin-off-main-thread': 2.2.3


### PR DESCRIPTION
This PR includes:
- updates pwa logic removing extra hash computations
- use pwa plugin integration entry to configure service worker and webmanifest base/scope properly
- remove webmanifest regeneration from ssg hook
- configure sw precache manifest properly using `prettyUrls` option
- use 404 as default navigation fallback if not configured
- fix `importModules` on Windows: check changes on `packages/iles/src/node/modules.ts`
