### PR TITLE
fix: get ext from the end of the file name

### DIFF
--- a/packages/iles/src/client/app/components/Island.vue
+++ b/packages/iles/src/client/app/components/Island.vue
@@ -50,7 +50,7 @@ export default defineComponent({
       strategy = Hydrate.OnLoad
     }
 
-    const ext = props.importFrom.split('.')[1]
+    const ext = props.importFrom.split('.').slice(-1)[0]
     const appConfig = useAppConfig()
     const framework: Framework = props.using
       || (ext === 'svelte' && 'svelte')


### PR DESCRIPTION
### Description 📖

Fix `Island.vue` component got error framework.

### Background 📜

`props.importFrom` will be the absolute path of component. If the username may contain '.', `Island.vue` component will get error framework.

### The Fix 🔨

Always get the ext from the end of filename