### PR TITLE
feat: update version of @vueuse/head

### DIFF
--- a/packages/iles/package.json
+++ b/packages/iles/package.json
@@ -69,7 +69,7 @@
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/devtools-api": "^6.4.5",
     "@vue/server-renderer": "^3.2.45",
-    "@vueuse/head": "^0.7.3",
+    "@vueuse/head": "^1.0.22",
     "debug": "^4.3.2",
     "deep-equal": "^2.0.5",
     "es-module-lexer": "^0.7.1",

--- a/packages/iles/src/node/build/render.ts
+++ b/packages/iles/src/node/build/render.ts
@@ -54,7 +54,7 @@ export async function renderPage (
   if (!route.outputFilename.endsWith('.html'))
     return content
 
-  const { headTags, htmlAttrs, bodyTags, bodyAttrs } = await renderHeadToString(head)
+  const { headTags, htmlAttrs, bodyTagsOpen, bodyTags, bodyAttrs } = await renderHeadToString(head)
 
   return `<!DOCTYPE html>
 <html ${htmlAttrs}>
@@ -64,6 +64,7 @@ export async function renderPage (
     ${await scriptTagsFrom(config, islandsByPath[route.path])}
   </head>
   <body ${bodyAttrs}>
+    ${bodyTagsOpen}
     <div id="app">${content}</div>
     ${bodyTags}
   </body>

--- a/packages/iles/src/node/build/render.ts
+++ b/packages/iles/src/node/build/render.ts
@@ -54,7 +54,7 @@ export async function renderPage (
   if (!route.outputFilename.endsWith('.html'))
     return content
 
-  const { headTags, htmlAttrs, bodyAttrs } = renderHeadToString(head)
+  const { headTags, htmlAttrs, bodyTags, bodyAttrs } = await renderHeadToString(head)
 
   return `<!DOCTYPE html>
 <html ${htmlAttrs}>
@@ -65,6 +65,7 @@ export async function renderPage (
   </head>
   <body ${bodyAttrs}>
     <div id="app">${content}</div>
+    ${bodyTags}
   </body>
 </html>`
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
       '@vitejs/plugin-vue': ^4.0.0
       '@vue/devtools-api': ^6.4.5
       '@vue/server-renderer': ^3.2.45
-      '@vueuse/head': ^0.7.3
+      '@vueuse/head': ^1.0.22
       chokidar: ^3
       conventional-changelog-cli: ^2.1.1
       debug: ^4.3.2
@@ -236,7 +236,7 @@ importers:
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.0+vue@3.2.45
       '@vue/devtools-api': 6.4.5
       '@vue/server-renderer': 3.2.45_vue@3.2.45
-      '@vueuse/head': 0.7.3_vue@3.2.45
+      '@vueuse/head': 1.0.22_vue@3.2.45
       debug: 4.3.2
       deep-equal: 2.0.5
       es-module-lexer: 0.7.1
@@ -3773,6 +3773,35 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: true
 
+  /@unhead/dom/1.0.15:
+    resolution: {integrity: sha512-W3P9eGazfQPMZTG4ryb5oOA02Z4o16Jxo8DAihF/7Xmg/FVYY5Up9p9et7Nbb6AKNgt1PEz3Sp0xBaw+F6Uyjw==}
+    dependencies:
+      '@unhead/schema': 1.0.15
+    dev: false
+
+  /@unhead/schema/1.0.15:
+    resolution: {integrity: sha512-aWgHDHcemcx20zZun2hCFvZC6Ob4h14D4puhknuQoMkMOZcxh2ffYoJHb6mS3TeQRwAXCOsSFIHAgwIbayjk0w==}
+    dependencies:
+      '@zhead/schema': 1.0.9
+      hookable: 5.4.2
+    dev: false
+
+  /@unhead/ssr/1.0.15:
+    resolution: {integrity: sha512-WNFljr+HaWdrBVYyKcgLXIk5EldPSKEVJlFbo2ixmSVGnFlqMHMCui/ZrfMLG1QvvFw0ZkXonapkEc/S6loSCQ==}
+    dependencies:
+      '@unhead/schema': 1.0.15
+    dev: false
+
+  /@unhead/vue/1.0.15_vue@3.2.45:
+    resolution: {integrity: sha512-D2NQH8fBKdYgTdIDrarx24qDEblgLIwzPDeAY36PyP6ib8oG6oaI+5lrpMG+NtQ7k9LBqL5d6mQgYn/02kdjZg==}
+    peerDependencies:
+      vue: '>=2.7 || >=3'
+    dependencies:
+      '@unhead/schema': 1.0.15
+      hookable: 5.4.2
+      vue: 3.2.45
+    dev: false
+
   /@vitejs/plugin-vue/4.0.0_vite@4.0.0+vue@3.2.45:
     resolution: {integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3962,11 +3991,15 @@ packages:
       vue-demi: 0.12.1
     dev: true
 
-  /@vueuse/head/0.7.3_vue@3.2.45:
-    resolution: {integrity: sha512-4IRwZlpO9NKiHEHGvsXEGfy8ZD53B7neAMLsnfzu/TocpO7y9pn55mHWpodWAeUFyf6kNgKxFq5yBGTxLni3aA==}
+  /@vueuse/head/1.0.22_vue@3.2.45:
+    resolution: {integrity: sha512-YmUdbzNdCnhmrAFxGnJS+Rixj+swE+TQC9OEaYDHIro6gE7W11jugcdwVP00HrA4WRQhg+TOQ4YcY2oL/PP1hw==}
     peerDependencies:
-      vue: '>=3'
+      vue: '>=2.7 || >=3'
     dependencies:
+      '@unhead/dom': 1.0.15
+      '@unhead/schema': 1.0.15
+      '@unhead/ssr': 1.0.15
+      '@unhead/vue': 1.0.15_vue@3.2.45
       vue: 3.2.45
     dev: false
 
@@ -4031,6 +4064,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@zhead/schema/1.0.9:
+    resolution: {integrity: sha512-MBubVXXEJX86ZBL6CDK0rYi1mC82zuben1MwwAEe98EFN1w4Oy0l2roJaM51MwQEvZ+WTi6o4lCxUShtLQJk8A==}
+    dev: false
 
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -6959,6 +6996,10 @@ packages:
       property-information: 6.1.1
       space-separated-tokens: 2.0.1
     dev: true
+
+  /hookable/5.4.2:
+    resolution: {integrity: sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==}
+    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}


### PR DESCRIPTION
### Description 📖

This pull request adds support for body tags by updating the page template in `renderPage()` and fixes #191 by @harlan-zw.

### Background 📜

`@vueuse/head` added support for tags at the `bodyClose` position. But the version used in the project didn't have that feature.

### The Fix 🔨

By updating the `@vueuse/head` version to the latest, and updating the page template to render `bodyTags` generated by that package, we can add support for tags placed at the end of the page.

### Screenshot

<img width="979" alt="Screenshot 2023-01-13 at 12 53 40 PM" src="https://user-images.githubusercontent.com/16580576/212278868-ab5eaf83-3ad7-4f59-b467-23f0006a5ccf.png">

