### PR TITLE
fix: rendering MDX images in development

### DIFF
--- a/packages/images/src/images.ts
+++ b/packages/images/src/images.ts
@@ -47,7 +47,7 @@ export default function IlesImagePresets (presets: ImagePresets, options?: Optio
         {
           name: '@islans/images:inject-mdx-component',
           transform (code, id) {
-            if (id.endsWith('composables/mdxComponents.js')) {
+            if (id.includes('/composables/mdxComponents.js')) {
               code = code.replace('inject(mdxComponentsKey)', '{ img: _Picture, ...inject(mdxComponentsKey) }')
               return `import _Picture from '${PICTURE_COMPONENT_PATH}'\n${code}`
             }


### PR DESCRIPTION
### Background 📜

The id looks like `composables/mdxComponents.js?v=a217f6bd` since around Vite v3.1.

This caused all images to be corrupted in dev mode.

### The Fix 🔨

Use `includes` instead of `endsWith` to check the `id`.

But I'm wondering why not use a remark plugin instead of the Vite plugin 🤔 (I haven't tried writing a remark plugin for `<Picture>` yet, maybe it simply doesn't work for some reason.)