### PR TITLE
fix: use functions instead of variables for String.prototype.replace

### DIFF
--- a/packages/iles/src/node/build/write.ts
+++ b/packages/iles/src/node/build/write.ts
@@ -52,11 +52,11 @@ async function writeRoute (config: AppConfig, manifest: Manifest, route: RouteTo
       content = content.replace(`<!--${island.placeholder}-->`,
         // TODO: Remove additional script tag once Firefox is fixed
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1737882
-        `<script></script><script type="module" async>${rebasedCode}</script>`)
+        () => `<script></script><script type="module" async>${rebasedCode}</script>`)
     }
 
     // Preload scripts for islands in the page.
-    route.rendered = content.replace('</head>', `${stringifyScripts(config, manifest, preloadScripts)}</head>`)
+    route.rendered = content.replace('</head>', () => `${stringifyScripts(config, manifest, preloadScripts)}</head>`)
   }
 
   route = await config.ssg.beforePageRender?.(route, config) || route

--- a/packages/iles/src/node/plugin/plugin.ts
+++ b/packages/iles/src/node/plugin/plugin.ts
@@ -108,7 +108,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
       },
       transform (code, id) {
         if (id === APP_COMPONENT_PATH && !isBuild && appConfig.debug)
-          return code.replace('const DebugPanel = () => null', `import DebugPanel from '${DEBUG_COMPONENT_PATH}'`)
+          return code.replace('const DebugPanel = () => null', () => `import DebugPanel from '${DEBUG_COMPONENT_PATH}'`)
       },
       handleHotUpdate ({ file, server }) {
         if (file === appPath) return [server.moduleGraph.getModuleById(USER_APP_REQUEST_PATH)!]

--- a/packages/mdx/src/mdx-vite-plugins.ts
+++ b/packages/mdx/src/mdx-vite-plugins.ts
@@ -50,7 +50,7 @@ export default function IlesMdx (options: MarkdownOptions = {}): Plugin[] {
       async transform (code, path) {
         if (!shouldTransform(path)) return
 
-        return code.replace('export default MDXContent', `
+        return code.replace('export default MDXContent', () => `
 import { defineComponent as $defineComponent } from 'iles/jsx-runtime'
 
 const _sfc_main = /* @__PURE__ */ $defineComponent(MDXContent, {${


### PR DESCRIPTION
### Description 📖

This pull request fixes all uses of `String.prototype.replace` where the second argument is a string expression containing variables, by using functions that return these expressions instead.

### Background 📜

This fixes #224.

### The Fix 🔨

https://stackoverflow.com/questions/28102491/javascript-better-way-to-escape-dollar-signs-in-the-string-used-by-string-prot
