### PR TITLE
Enable nested headings using the `isNested` option

### DIFF
--- a/docs/iles.config.ts
+++ b/docs/iles.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   jsx: 'preact',
   debug: false,
   modules: [
-    headings(),
+    headings({ isNested: true }),
     icons(),
     prism(),
     lastUpdated(),

--- a/docs/src/components/TableOfContents.vue
+++ b/docs/src/components/TableOfContents.vue
@@ -2,32 +2,12 @@
 import type { Heading } from '@islands/headings'
 import type { SideBarItem } from '~/logic/config'
 
-interface HeadingWithChildren extends Heading {
-  children?: Heading[]
-}
-
 let { meta, frontmatter } = usePage()
 let level = $computed(() => frontmatter.tocLevel || (frontmatter.sidebar === 'auto' ? 3 : 2))
 
-let headings = $computed(() => resolveHeaders(meta.headings || []))
+let headings = $computed(() => mapHeaders((meta.headings || [])[0].children))
 
-function resolveHeaders (headings: Heading[]): SideBarItem[] {
-  return mapHeaders(groupHeaders(headings))
-}
-
-function groupHeaders (headings: Heading[]): HeadingWithChildren[] {
-  headings = headings.map(h => Object.assign({}, h))
-  let lastHeading: HeadingWithChildren
-  headings.forEach((h) => {
-    if (h.level === level)
-      lastHeading = h
-    else if (lastHeading)
-      (lastHeading.children || (lastHeading.children = [])).push(h)
-  })
-  return headings.filter(h => h.level === level)
-}
-
-function mapHeaders (headings: HeadingWithChildren[]): SideBarItem[] {
+function mapHeaders (headings: Heading[]): SideBarItem[] {
   return headings.map(Heading => ({
     text: Heading.title,
     link: `#${Heading.slug}`,

--- a/packages/headings/README.md
+++ b/packages/headings/README.md
@@ -32,6 +32,10 @@ An [îles] module that injects a [rehype] plugin to parse headings in
 
 - 📖 sets `meta.headings` to enable rendering sidebars and table of contents
 
+- 🔢 sets `data-indices` on headings for numbered sections (e.g. §4.20)
+
+- 🌲 supports nested headings:wq
+
 ### Usage 🚀
 
 ```ts

--- a/packages/headings/src/headings.ts
+++ b/packages/headings/src/headings.ts
@@ -1,9 +1,8 @@
-import type { Program, VariableDeclarator } from 'estree'
-import type { Pluggable, Plugin } from 'unified'
-import type { Data, Parent } from 'unist'
+import type { Plugin } from 'unified'
+import type { Parent } from 'unist'
 import type { IlesModule } from 'iles'
 
-import { Node, toString } from 'hast-util-to-string'
+import { toString } from 'hast-util-to-string'
 import { headingRank } from 'hast-util-heading-rank'
 import slugo from 'slugo'
 


### PR DESCRIPTION
### Description 📖

This pull request adds a new `isNested` boolean option the `@islands/headings` module. It can be used as follows:

```ts
import { defineConfig } from 'iles'

import headings from '@islands/headings'

export default defineConfig({
  modules: [
    headings({ isNested: true }) // `true` for nested headings, `false` otherwise
  ],
})
```

### Background 📜

See #226

### The Fix 🔨

By changing the `rehypePlugin` to automatically insert the current heading as a child of the last known heading of higher level, the structure of the `headings` object becomes a tree instead of a list. Now the `headings` only contains the list of top-level headings, with all others available inside their `children` field recursively.

### Screenshots 📷

See the following Debug output from a dummy post in my îles blog project.

```json
{
  "layout": "post",
  "frontmatter": {
    "path": "/blog/posts/my_title",
    "title": "My Title",
    "date": "2023-01-07T00:00:00.000Z",
    "isFeatured": true
  },
  "meta": {
    "filename": "src/pages/blog/posts/my_title.mdx",
    "lastUpdated": "2023-01-31T20:05:42.835Z",
    "href": "/blog/posts/my_title",
    "title": "Duis ultrices augues",
    "headings": [
      {
        "level": 1,
        "title": "Duis ultrices augues",
        "slug": "duis-ultrices-augues",
        "children": [
          {
            "level": 2,
            "title": "Morbi eu iaculis",
            "slug": "morbi-eu-iaculis",
            "children": [
              {
                "level": 3,
                "title": "Sed dapibus",
                "slug": "sed-dapibus",
                "children": [
                  {
                    "level": 4,
                    "title": "Fusce a mollis mauris",
                    "slug": "fusce-a-mollis-mauris",
                    "children": [],
                    "indices": [
                      1,
                      1,
                      1,
                      1
                    ]
                  }
                ],
                "indices": [
                  1,
                  1,
                  1
                ]
              }
            ],
            "indices": [
              1,
              1
            ]
          }
        ],
        "indices": [
          1
        ]
      },
      {
        "level": 1,
        "title": "Phasellus dui dui",
        "slug": "phasellus-dui-dui",
        "children": [
          {
            "level": 6,
            "title": "Mauris at augue vel ante",
            "slug": "mauris-at-augue-vel-ante",
            "children": [],
            "indices": [
              2,
              1
            ]
          }
        ],
        "indices": [
          2
        ]
      }
    ],
    "excerpt": "This is my post."
  },
  "props": {}
}
```