### PR TITLE
fix: relax @islands/feed pinned version of îles

### DIFF
--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -32,7 +32,7 @@
     "vue": "^3.2.45"
   },
   "peerDependencies": {
-    "iles": "workspace:^0.8",
+    "iles": "workspace:*",
     "vue": "^3.2.45"
   },
   "dependencies": {


### PR DESCRIPTION
### Description 📖

Fixes #230 by @dhruvkb

### Background 📜

This was happening because the version of `iles` pinned in the dependencies is older than the current version `0.9.x`.

### The Fix 🔨

By relaxing this pinning, we can allow the package to be installed in projects using the latest version of îles.
