### PR TITLE
Fix style for displaying language in Prism

### DIFF
--- a/packages/prism/README.md
+++ b/packages/prism/README.md
@@ -151,7 +151,11 @@ pre.line-numbers {
 If you wish to display the language, you can use the value of the `data-lang` attribute by using the [`attr` CSS function](https://developer.mozilla.org/en-US/docs/Web/CSS/attr()):
 
 ```css
-div[class*='language-']:before {
+div[class*='language-'] {
+  position: relative;
+}
+
+div[class*='language-']::before {
   content: attr(data-lang);
   color: #888;
   font-size: 0.8rem;


### PR DESCRIPTION
### Description 📖

This pull request fixes the CSS snippet for displaying language in the code preview generated by the `@islands/prism` plugin.

### Background 📜

The included code snippet did not work because
- the language `div` needs to be relatively positioned
- the `::before` pseudo-element needs two colons

### The Fix 🔨

By adding `position: relative` and the missing colon, these problems can be fixed.

### Screenshots 📷

<img width="756" alt="Screenshot 2023-09-15 at 3 02 30 PM" src="https://github.com/ElMassimo/iles/assets/16580576/96442636-d6c9-4950-8981-2cf3570d63f4">
