### PR TITLE
fix: 🐛 Ensure app.ts, site.ts, default layout are optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build
         run: pnpm build:all
 
+      - name: Build Blog Site
+        run: pnpm blog:build
+
       - name: Tests
         run: pnpm test
 

--- a/docs/src/pages/config/index.mdx
+++ b/docs/src/pages/config/index.mdx
@@ -11,7 +11,6 @@ sidebar: auto
 [meta tags]: /guide/meta-tags
 [sitemap]: /guide/development#sitemap
 
-[shortcodes]: /guide/markdown#advanced-provide-components-shortcodes
 [deployment]: /guide/deployment 
 [VitePress]: /faqs#vitepress
 [turbo]: /guide/turbo
@@ -48,7 +47,7 @@ export default defineConfig({
 You may provide an `iles.config.ts` configuration file to customize settings
 related to markdown, component resolution, and other îles-specific features.
 
-You can leverage your IDE's intellisense with jsdoc type hints or use the `defineConfig` helper:
+You can leverage your IDE's intellisense by using the `defineConfig` helper:
 
 ```ts
 import { defineConfig } from 'iles'
@@ -155,83 +154,6 @@ When set, it is exposed as `site.url` and `site.canonical`.
 - **Default:** `true`
 
 Whether to output more information about islands and hydration in development.
-
-## Your App
-
-<Iles/> will pre-configure a Vue 3 app that will load any [pages] defined in the
-site.
-
-You may provide additional configuration in `src/app.ts`, and leverage
-intellisense by using the `defineApp` helper.
-
-```ts
-import { defineApp } from 'iles'
-
-export default defineApp({
-  head ({ frontmatter, site }) {
-    return {
-      meta: [
-        { property: 'author', content: site.author },
-        { property: 'keywords', content: computed(() => frontmatter.tags) },
-      ]
-    }
-  },
-  enhanceApp ({ app, head, router }) {
-    // Configure the app to add plugins.
-  },
-  router: {
-    scrollBehavior (current, previous, savedPosition) {
-      // Configure the scroll behavior
-    }, 
-  },
-})
-```
-
-### `head`
-
-- **Type:** `HeadObject | (context: AppContext) => HeadObject`
-
-Set the page title, meta tags, additional CSS, or scripts using [`@unhead/vue`][@unhead/vue].
-
-### `enhanceApp`
-
-- **Type:** `(context: AppContext) => Promise<void>`
-
-A hook where you can add plugins to the Vue app, or do anything else prior to
-the app being mounted.
-
-### `mdxComponents`
-
-- **Type:** `MDXComponents | (context: AppContext) => MDXComponents`
-
-Provide an object that [maps tag names in MDX to components][shortcodes] to render.
-
-```ts
-import { defineApp } from 'iles'
-import Image from '~/components/Image.vue'
-
-export default defineApp({
-  mdxComponents: {
-    b: 'strong',
-    img: Image,
-  },
-})
-```
-
-### `router`
-
-- **Type:** `RouterOptions`
-
-Configure [`vue-router`][vue-router] by providing options such as `scrollBehavior` and `linkActiveClass`.
-
-### `socialTags`
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Some social tags can be inferred from the <kbd>[site]</kbd>.
-
-Set it to `false` to avoid adding social tags such as `og:title` and `twitter:description`.
 
 ## `iles.config.ts` Example
 

--- a/docs/src/pages/guide/development.mdx
+++ b/docs/src/pages/guide/development.mdx
@@ -10,6 +10,11 @@
 [siteUrl]: /config#siteurl
 [useDocuments]: /guide/documents
 [frameworks]: /guide/frameworks
+[head and meta tags]: /guide/meta-tags
+[discussion]: https://github.com/ElMassimo/iles/discussions/6#discussioncomment-1479755
+[`@unhead/vue`]: https://unhead.unjs.io/setup/vue/installation
+[shortcodes]: /guide/markdown#advanced-provide-components-shortcodes
+[vue-router]: https://next.router.vuejs.org/
 
 # Development 💻
 
@@ -35,8 +40,8 @@ In this section, we'll cover the basics to start building an <Iles/> application
   │    ├── about.vue
   │    └── index.mdx
   │
-  ├── <kbd><a href="/config#your-app">app.ts</a></kbd>
-  └── <kbd><a href="#site">site.ts</a></kbd></code>
+  ├── <kbd><a href="#site">site.ts</a></kbd>
+  └── <kbd><a href="#app-2">app.ts</a></kbd></code>
 </pre>
 </div>
 
@@ -55,6 +60,34 @@ import { useDark } from '~/logic/dark'
 Components in the <kbd>src/components</kbd> dir will be auto-imported on-demand, powered by [`unplugin-vue-components`](https://github.com/antfu/unplugin-vue-components).
 
 <Iles/> extends this so that you don't need to import components in [MDX files][mdx].
+
+## Layouts 📐
+
+Components in the <kbd>src/layouts</kbd> dir will be available as layouts, and they should provide a default `<slot/>`. 
+
+Pages may specify a layout using the `layout` property in frontmatter:
+
+```md
+---
+layout: post
+---
+```
+
+Layouts and Vue pages can also specify a parent layout using a `layout` attribute in the `template`:
+
+```vue
+<template layout="post">
+```
+
+> Layouts are optional; however, having a default layout is highly recommended.
+>
+> The `default` layout will be used for all pages unless specified.
+> 
+> Pages may opt-out by specifying `layout: false`
+
+<Tip warn>
+Layout files must be lowercase, as in `post.vue` or `default.vue`.
+</Tip>
 
 ## Pages 🛣
 
@@ -142,32 +175,6 @@ const posts = usePosts()
 </template>
 ```
 
-## Layouts 📐
-
-Components in the <kbd>src/layouts</kbd> dir will be available as layouts, and they should provide a default `<slot/>`.
-
-Pages may specify a layout using the `layout` property in frontmatter:
-
-```md
----
-layout: post
----
-```
-
-Layouts and Vue pages can also specify a parent layout using a `layout` attribute in the `template`:
-
-```vue
-<template layout="post">
-```
-
-> The `default` layout will be used for all pages unless specified.
->
-> Pages may opt-out by specifying `layout: false`
-
-<Tip warn>
-Layout files must be lowercase, as in `post.vue` or `default.vue`.
-</Tip>
-
 ## Site 🌐
 
 `src/site.ts` can be used to provide site-wide information such as `title`, `description`, etc.
@@ -183,10 +190,123 @@ export default {
 }
 ```
 
+It can be accessed as `$site` in component instances, or by using `usePage`.
+
+```vue
+<script setup>
+import { usePage } from 'iles' // not needed
+
+const { site } = usePage()
+</script>
+```
+
+It's also displayed in the page information in _Islands_ devtools.
+
+> Adding `src/site.ts` to your project is optional.
+> 
+> Alternatively, you can use composables from [`@unhead/vue`] to manage the [head and meta tags] of your page.
+
+## App 📱
+
+<Iles/> will pre-configure a Vue 3 shell that, during development, will load your site comprising of your [layouts](#layouts) and [pages](#pages) within it.
+
+`src/app.ts` can be used to provide additional configurations with the `defineApp` helper, allowing you to customize:
+- using `enhanceApp`, the development and build logic of this "outer" shell.
+- your site's head and meta tags, scroll behavior, etc.
+
+> This "outer" shell is loaded only during development and is not included in your built site.
+>
+> Adding `src/app.ts` to your project is optional.
+
+```ts
+import { defineApp } from 'iles'
+
+export default defineApp({
+  enhanceApp ({ app, head, router }) {
+    // Configure the "outer" shell to customize it's development/build logic
+  },
+  head ({ frontmatter, site }) {
+    return {
+      meta: [
+        { property: 'author', content: site.author },
+        { property: 'keywords', content: computed(() => frontmatter.tags) },
+      ]
+    }
+  },
+  router: {
+    scrollBehavior (current, previous, savedPosition) {
+      // Configure the scroll behavior
+    }, 
+  },
+  mdxComponents: {
+      // Options for tag mapping in MDX
+  },
+  socialTags: true // default
+})
+```
+
+### `enhanceApp` (Development only)
+
+- **Type:** `(context: AppContext) => void | Promise<void>`
+
+A hook where you can add additional development/build logic. See this [discussion] thread for few suggestions.
+
+### `head`
+
+- **Type:** `HeadObject | (context: AppContext) => HeadObject`
+
+Set the page title, meta tags, additional CSS, or scripts using [`@unhead/vue`].
+
+### `router`
+
+- **Type:** `RouterOptions`
+
+Configure [`vue-router`][vue-router] by providing options such as `scrollBehavior` and `linkActiveClass`.
+
+### `mdxComponents`
+
+- **Type:** `MDXComponents | (context: AppContext) => MDXComponents`
+
+Provide an object that [maps tag names in MDX to components][shortcodes] to render.
+
+```ts
+import { defineApp } from 'iles'
+import Image from '~/components/Image.vue'
+
+export default defineApp({
+  mdxComponents: {
+    b: 'strong',
+    img: Image,
+  },
+})
+```
+
+### `socialTags`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Some social tags can be inferred from the <kbd>[site](#site)</kbd>.
+
+Set it to `false` to avoid adding social tags such as `og:title` and `twitter:description`.
+
+## Devtools 🛠
+
+Page information is available in a debug panel, similar to VitePress, but you may also access an _Islands_ inspector in Vue devtools.
+
+This can be useful when debugging [islands hydration][hydration].
+
+## Iles Configuration ⚙️
+
+You may provide a `iles.config.ts` configuration file at your project root to customize the various îles-specific features.
+
+You may also provide a `vite.config.ts` configuration file (or use the `vite` key in `iles.config.ts`) to add vite plugins and customize the various vite-specific features.
+
 ### Sitemap 🗺
 
-A sitemap can be automatically generated for your site, all you need to do is
-configure <kbd>[siteUrl]</kbd>. That will also make it available as `site.url` and `site.canonical`.
+A sitemap can be automatically generated when you build your site, all you need to do is configure <kbd>[siteUrl]</kbd> in your `iles.config.ts` configuration file. 
+
+If configured, `siteUrl` will also make it available as `site.url` and `site.canonical`.
 
 ```ts
 import { defineConfig } from 'iles'
@@ -206,8 +326,4 @@ export default defineConfig({
 })
 ```
 
-## Devtools 🛠
-
-Page information is available in a debug panel, similar to VitePress, but you may also access an _Islands_ inspector in Vue devtools.
-
-This can be useful when debugging [islands hydration][hydration].
+> To learn more about further Iles and Vite configurations, refer to the [config] page.

--- a/docs/src/pages/guide/meta-tags.mdx
+++ b/docs/src/pages/guide/meta-tags.mdx
@@ -1,6 +1,8 @@
-[@unhead/vue]: https://github.com/@unhead/vue
-[app]: /config#your-app
-[useHead]: https://github.com/@unhead/vue#api
+[@unhead/vue]: https://unhead.unjs.io/setup/vue/installation
+[app]: /guide/development#app-2
+[useHead]: https://unhead.unjs.io/usage/composables/use-head
+[useSeoMeta]: https://unhead.unjs.io/usage/composables/use-seo-meta
+[Head]: https://unhead.unjs.io/setup/vue/components
 [site]: /guide/development#site
 [frontmatter]: /guide/development#pages
 

--- a/packages/iles/src/client/app/composables/pageData.ts
+++ b/packages/iles/src/client/app/composables/pageData.ts
@@ -42,6 +42,12 @@ export function installPageData (app: App, siteRef: Ref<UserSite>): PageData {
   const meta = reactiveFromFn(() => page.value.meta || {})
   const frontmatter = reactiveFromFn(() => page.value.frontmatter || {})
   const props = computedInPage(() => propsFromRoute(route))
+
+  siteRef.value = {
+    title: 'Îles',
+    description: 'An Îles Site',
+    ...siteRef.value,
+  }
   const site = toReactive(siteRef)
 
   const pageData: PageData = { route, page, meta, frontmatter, site, props }

--- a/packages/iles/src/client/app/index.ts
+++ b/packages/iles/src/client/app/index.ts
@@ -4,9 +4,7 @@ import { createHead } from '@unhead/vue'
 
 import routes from '@islands/routes'
 import config from '@islands/app-config'
-import userApp from '@islands/user-app'
-import siteRef from '@islands/user-site'
-import type { CreateAppFactory, AppContext, RouterOptions } from '../shared'
+import type { CreateAppFactory, AppContext, RouterOptions, UserApp, UserSite } from '../shared'
 import App from './components/App.vue'
 import { installPageData, forcePageUpdate } from './composables/pageData'
 import { installMDXComponents } from './composables/mdxComponents'
@@ -32,7 +30,27 @@ function createRouter (base: string | undefined, routerOptions: Partial<RouterOp
   })
 }
 
+function unwrapModule (mod: any): any {
+  return mod && mod.default ? unwrapModule(mod.default) : mod
+}
+
 export const createApp: CreateAppFactory = async (options = {}) => {
+  let userApp: UserApp
+  try {
+    userApp = unwrapModule(await import('@islands/user-app'))
+  }
+  catch (err) {
+    userApp = {}
+  }
+  
+  let siteRef: UserSite
+  try {
+    siteRef = unwrapModule(await import('@islands/user-site'))
+  }
+  catch (err) {
+    siteRef = {}
+  }
+  
   const { head: headConfig, enhanceApp, router: routerOptions } = userApp
   const { routePath = config.base, ssrProps } = options
 

--- a/packages/iles/src/node/alias.ts
+++ b/packages/iles/src/node/alias.ts
@@ -30,9 +30,13 @@ export const APP_CONFIG_REQUEST_PATH = `/${APP_CONFIG_ID}`
 
 export const USER_APP_ID = '@islands/user-app'
 export const USER_APP_REQUEST_PATH = `/${USER_APP_ID}`
+export const USER_APP_ID_VIRTUAL = 'virtual:user-app'
+export const USER_APP_ID_VIRTUAL_RESOLVED = `\0${USER_APP_ID_VIRTUAL}`
 
 export const USER_SITE_ID = '@islands/user-site'
 export const USER_SITE_REQUEST_PATH = `/${USER_SITE_ID}`
+export const USER_SITE_ID_VIRTUAL = 'virtual:user-site'
+export const USER_SITE_ID_VIRTUAL_RESOLVED = `\0${USER_SITE_ID_VIRTUAL}`
 
 export const NOT_FOUND_REQUEST_PATH = '@islands/components/NotFound'
 
@@ -40,7 +44,9 @@ export function resolveAliases (root: string, userConfig: UserConfig): AliasOpti
   const paths: Record<string, string> = {
     '/@shared': SHARED_PATH,
     [USER_APP_ID]: USER_APP_REQUEST_PATH,
+    [USER_APP_ID_VIRTUAL]: USER_APP_ID_VIRTUAL_RESOLVED,
     [USER_SITE_ID]: USER_SITE_REQUEST_PATH,
+    [USER_SITE_ID_VIRTUAL]: USER_SITE_ID_VIRTUAL_RESOLVED,
     [APP_CONFIG_ID]: APP_CONFIG_REQUEST_PATH,
   }
 

--- a/packages/iles/src/node/config.ts
+++ b/packages/iles/src/node/config.ts
@@ -310,6 +310,8 @@ function viteConfigDefaults (root: string, userConfig: UserConfig): ViteOptions 
         '@islands/hydration',
         '@islands/prerender',
         'vue/server-renderer',
+        'virtual:user-app',
+        'virtual:user-site',
       ],
     },
   }

--- a/packages/iles/src/node/plugin/middleware.ts
+++ b/packages/iles/src/node/plugin/middleware.ts
@@ -17,6 +17,13 @@ const debug = createDebugger('iles:html-page-fallback')
 export function configureMiddleware (config: AppConfig, server: ViteDevServer, defaultLayoutPath: string) {
   restartOnConfigChanges(config, server)
 
+  // If user included the vite vue plugin via their own vite.config.ts, then iles's vite vue plugin will consume a transformed sfc and error out. So, error out and alert user
+  const vueVitePlugins = server.config.plugins.filter(plugin => plugin.name === 'vite-plugin-vue' || plugin.name === 'vite:vue')
+
+  if (vueVitePlugins.length > 1) {
+    throw new Error(`[îles] Duplicate Vue Vite plugin detected. Ensure @vitejs/plugin-vue is removed from the Vite plugins array in vite.config.ts or iles.config.ts. Use the 'vue' property in iles.config.ts to pass any configuration to the Vue Vite plugin which is already included by îles.\n`)
+  }
+
   const htmlPagesMiddleware: Connect.NextHandleFunction = function ilesHtmlPagesMiddleware (req, res, next) {
     let { url = '' } = req
 

--- a/packages/iles/src/node/plugin/plugin.ts
+++ b/packages/iles/src/node/plugin/plugin.ts
@@ -216,12 +216,15 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
         }
 
         if (isPage) {
+          const layoutPath = `${layoutsRoot}/${layout}.vue`
+          const layoutExists = await exists(resolve(root, layoutPath.slice(1)))
+
           appendToSfc('layoutName', serialize(layout))
-          appendToSfc('layoutFn', String(layout) === 'false'
+          appendToSfc('layoutFn', String(layout) === 'false' || !layoutExists
             ? 'false'
             : `() => import('${layoutsRoot}/${layout}.vue').then(m => m.default)`)
         }
-
+        
         return s.toString()
       },
     },

--- a/packages/iles/tests/__snapshots__/build.spec.ts.snap
+++ b/packages/iles/tests/__snapshots__/build.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`building docs site > html files 1`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -74,7 +74,7 @@ exports[`building docs site > html files 2`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -121,7 +121,7 @@ exports[`building docs site > html files 3`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -160,7 +160,7 @@ exports[`building docs site > html files 4`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -197,7 +197,7 @@ exports[`building docs site > html files 5`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -269,7 +269,7 @@ exports[`building docs site > html files 6`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >
@@ -374,7 +374,7 @@ exports[`building docs site > html files 7`] = `
 <meta property="twitter:card" content="summary">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/assets/default-.css">
-<link rel="stylesheet" href="/assets/app.css">
+<link rel="stylesheet" href="/assets/user-app.css">
     
   <script type="module" async src="/assets/turbo.BkUC-S31.js"></script></head>
   <body >

--- a/packages/iles/tests/build.spec.ts
+++ b/packages/iles/tests/build.spec.ts
@@ -18,8 +18,8 @@ describe('building docs site', () => {
     expect(files.sort()).toEqual(expect.arrayContaining([
       '404.html',
       '_headers',
-      'assets/app-Y_77dvPh.css',
       'assets/turbo.BkUC-S31.js',
+      'assets/user-app-Y_77dvPh.css',
       'favicon.ico',
       'feed.rss',
       'index.html',
@@ -45,7 +45,7 @@ describe('building docs site', () => {
   })
 
   test('styles', async () => {
-    await assertSnapshot('assets/app-Y_77dvPh.css')
+    await assertSnapshot('assets/user-app-Y_77dvPh.css')
     await assertSnapshot('assets/default--6gluetn.css')
   })
   test('sitemap', async () => {
@@ -99,7 +99,7 @@ async function assertHTML (path: string, { title }: any = {}) {
   expectContent.toContain('<link rel="sitemap" href="https://the-vue-point-with-iles.netlify.app/sitemap.xml">')
   expectContent.toContain(`<meta property="og:url" content="https://the-vue-point-with-iles.netlify.app/${path.replace('index.html', '')}">`)
   expectContent.toContain('<link rel="stylesheet" href="/assets/default-.css">')
-  expectContent.toContain('<link rel="stylesheet" href="/assets/app.css">')
+  expectContent.toContain('<link rel="stylesheet" href="/assets/user-app.css">')
 
   expectContent.toContain('<ile-root id="ile-1">'
     + '<div class="text-sm text-gray-500 leading-5">'

--- a/packages/iles/tsconfig.json
+++ b/packages/iles/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "module": "esnext",
     "target": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "strict": true,
     "declaration": true,

--- a/packages/iles/types/virtual.d.ts
+++ b/packages/iles/types/virtual.d.ts
@@ -24,7 +24,17 @@ declare module '@islands/user-app' {
   export default config
 }
 
+declare module 'virtual:user-app' {
+  const config: import('./shared').UserApp
+  export default config
+}
+
 declare module '@islands/user-site' {
+  const config: import('vue').Ref<import('./shared').UserSite>
+  export default config
+}
+
+declare module 'virtual:user-site' {
   const config: import('vue').Ref<import('./shared').UserSite>
   export default config
 }


### PR DESCRIPTION
This PR covers:

## fix: 🐛 Ensure default layout is optional when user didn't create one

Ensure default layout is optional when user didn't create one

While build works when user didn't provide a default layout at `src/layouts/default.vue`, development throws the below error (one of those dev vs prod differences). To test, scaffold a new iles project with `pnpm create iles@next`, delete layouts folder, and start dev-server, the following error will be thrown. 

<img width="1350" alt="image" src="https://github.com/user-attachments/assets/7afdee9d-3b27-47e7-a636-50809ad4951c" />

## fix: 🐛 Error out on duplicate Vite Vue plugins with error message

Error out on duplicate Vite Vue plugins with error message. 

When Îles is added to an existing vite-vue project, the exisitng `vite.config.ts` containing the Vue-Vite plugin. 

Îles already includes it, and two Vue-Vite plugin creates issues, as one outputs transformed SFC to the other which considers it as invalid. 

This PR errors out & alerts user with the below message to remove the Vue-Vite plugin from their `vite.config.ts` and use the `vue` property in `iles.config.ts`. 

<img width="993" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/67101203-4018-4566-bac9-5f4a27f48aa9" />

## fix: 🐛 Use default title and description to avoid undefined when user had empty site.ts

Use default title and description to avoid undefined when user had empty site.ts. 

At the moment `site.ts` is mandatory, and while the user provides it, they can have an empty `export default {}` which results in `undefined` being shown as title/description, refer to below screenshot. 

![Vue's official documentation provides you with all information you need to get started](https://github.com/user-attachments/assets/44478322-4943-496b-80b1-dbb366ee5c33)

This PR shows a placeholder like Vitepress. Also subsequent PR makes `site.ts` optional. 

<img width="1348" alt="image" src="https://github.com/user-attachments/assets/4ac64e16-048f-4a1d-a81c-0058b9f825a0" />

## Chores:
- test: 🧪 Updated previous snapshot for related asset naming change from app-*.css to user-app-*.css

## Docs:
- docs: 📝 Moved app.ts docs section from config to development, config is now purely iles.config.ts related