### PR TITLE
feat: ✨ Support useSeoMeta from @unhead/vue, docs updated

### DIFF
--- a/docs/composables.d.ts
+++ b/docs/composables.d.ts
@@ -5,6 +5,7 @@ declare global {
   const definePageComponent: typeof import('iles')['definePageComponent']
   const useDocuments: typeof import('iles')['useDocuments']
   const useHead: typeof import('iles')['useHead']
+  const useSeoMeta: typeof import('iles')['useSeoMeta']
   const usePage: typeof import('iles')['usePage']
   const useRoute: typeof import('iles')['useRoute']
 }

--- a/docs/src/components/AutoImported.vue
+++ b/docs/src/components/AutoImported.vue
@@ -1,5 +1,5 @@
 <template>
   <Tip title="Composables are auto-imported">
-    You don't need to import <kbd>usePage</kbd>, <kbd>useRoute</kbd>, <kbd>useHead</kbd>, or <kbd>definePageComponent</kbd>.
+    You don't need to import <kbd>usePage</kbd>, <kbd>definePageComponent</kbd>, <kbd>useRoute</kbd>, <kbd>useHead</kbd> or <kbd>useSeoMeta</kbd>.
   </Tip>
 </template>

--- a/docs/src/pages/config/index.mdx
+++ b/docs/src/pages/config/index.mdx
@@ -19,6 +19,9 @@ sidebar: auto
 [drafts]: /guide/markdown
 [useDocuments]: /guide/documents
 
+[vue-router]: https://next.router.vuejs.org/
+[@unhead/vue]: https://unhead.unjs.io/setup/vue/installation
+
 # Configuration
 
 The following section is an overview of basic configuration for <Iles/>.
@@ -263,8 +266,3 @@ export default defineConfig({
   },
 })
 ```
-
-
-[vue-router]: https://next.router.vuejs.org/
-[@unhead/vue]: https://github.com/@unhead/vue
-[site]: #the-site

--- a/docs/src/pages/faqs/index.mdx
+++ b/docs/src/pages/faqs/index.mdx
@@ -15,6 +15,8 @@
 [podcast]: https://dev.to/viewsonvue/islands-architecture-in-vue-with-maximo-mussini-vue-170
 
 [prettyUrls]: /config#prettyurls
+[vue-router]: https://next.router.vuejs.org/
+[@unhead/vue]: https://unhead.unjs.io/setup/vue/installation
 
 # FAQs
 
@@ -97,8 +99,5 @@ Use Astro if you are not familiar with Vue, or don't like its template syntax.
 - [vue-router], [@unhead/vue], and [vite-plugin-pages]: the backbone of this library
 - [unplugin-vue-components]: allows you to avoid the boilerplate
 - [VitePress] and [vite-ssg]: for their different ideas on SSR
-
-[vue-router]: https://next.router.vuejs.org/
-[@unhead/vue]: https://github.com/@unhead/vue
 
 <Contact/>

--- a/docs/src/pages/guide/meta-tags.mdx
+++ b/docs/src/pages/guide/meta-tags.mdx
@@ -1,6 +1,8 @@
-[@unhead/vue]: https://github.com/@unhead/vue
+[@unhead/vue]: https://unhead.unjs.io/setup/vue/installation
 [app]: /config#your-app
-[useHead]: https://github.com/@unhead/vue#api
+[useHead]: https://unhead.unjs.io/usage/composables/use-head
+[useSeoMeta]: https://unhead.unjs.io/usage/composables/use-seo-meta
+[Head]: https://unhead.unjs.io/setup/vue/components
 [site]: /guide/development#site
 [frontmatter]: /guide/development#pages
 
@@ -12,32 +14,76 @@ for commonly used meta tags.
 
 There are several ways to customize `title` and `meta` tags in <Iles/>, powered by <kbd>[@unhead/vue]</kbd>.
 
-## [`useHead` Composable][useHead]
+## `useHead` Composable
 
-This helper can be used in the `setup` function or `<script setup>` of any Vue component.
+[useHead] can be used within the `setup` function or `<script setup>` of any Vue component.
 
 ```vue
 <script setup lang="ts">
 import { computed } from 'vue' 
   
 const { frontmatter } = usePage()
+const { title, description, tags, image } = frontmatter
 
 useHead({
+  title,
+  description,
   meta: [
+    // useSeoMeta can be used to better manage meta tags
     { property: 'og:type', content: 'website' },
-    { property: 'keywords', content: computed(() => frontmatter.tags) },
+    { property: 'og:image', content: image },
   ],
+  htmlAttrs: { lang: 'en-US' },
+  bodyAttrs: { class: 'dark-mode', 'data-theme': 'light' },
+  link: [],
+  style: [],
+  noscript: [],
+  // useScript can also be used to load scripts
+  script: [],
 })
 </script>
 ```
 
-Notice that values can be static or computed.
+> `useHead` options support both static values and reactive variables, such as `ref`, `computed`, and `reactive`.
+
+## `useSeoMeta` Composable
+
+[useSeoMeta] can be used within the `setup` function or `<script setup>` of any Vue component.
+
+It lets you define your site's SEO meta as a flat object and helps you avoid common mistakes, such as using `name` instead of `property` as well typos with over 100+ meta tags fully typed.
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue' 
+  
+const { frontmatter } = usePage()
+const { title, description, tags, image } = frontmatter
+
+useSeoMeta({
+  // Refer to type definition for the full list
+  title,
+  description,
+  author: 'Máximo Mussini',
+  charset: 'utf-8',
+  viewport: 'width=device-width, initial-scale=1',
+  generator: 'Îles v0.10.0-beta.1',
+  keywords: tags?.toString(),
+  ogTitle: title,
+  ogDescription: description,
+  ogType: 'website',
+  ogImage: image,
+  ogImageAlt: title,
+})
+</script>
+```
+
+> `useSeoMeta` options support both static values and reactive variables, such as `ref`, `computed`, and `reactive`.
 
 <AutoImported/>
 
-## [`<Head>` Component](https://github.com/@unhead/vue#head)
+## `<Head>` Component
 
-Besides <kbd>[useHead]</kbd>, you can also manipulate head tags using the `<Head>` component:
+Besides <kbd>[useHead](#usehead-composable)</kbd> and <kbd>[useSeoMeta](#useseometa-composable)</kbd>, you can also manipulate head tags using the [`<Head>`][Head] component:
 
 ```vue
 <template>
@@ -52,10 +98,10 @@ Besides <kbd>[useHead]</kbd>, you can also manipulate head tags using the `<Head
 
 This is often more intuitive, specially for dynamic values.
 
-## [App Meta Tags][app]
+## App Meta Tags
 
 Finally, you can use `head` in <kbd>[src/app.ts][app]</kbd>, which supports the
-same format as <kbd>[useHead]</kbd>.
+same format as <kbd>[useHead](#usehead-composable)</kbd>.
 
 ```ts
 import { defineApp } from 'iles'
@@ -63,6 +109,7 @@ import { defineApp } from 'iles'
 export default defineApp({
   head: {
     htmlAttrs: { lang: 'en-US' },
+    bodyAttrs: { class: 'dark-mode', 'data-theme': 'light' },
   },
 })
 ```
@@ -77,7 +124,7 @@ export default defineApp({
     return {
       meta: [
         { property: 'author', content: site.author },
-        { property: 'keywords', content: computed(() => frontmatter.tags) },
+        { property: 'keywords', content: () => frontmatter.tags },
       ]
     }
   },

--- a/docs/src/pages/guide/static-assets.mdx
+++ b/docs/src/pages/guide/static-assets.mdx
@@ -1,0 +1,83 @@
+[meta tags]: /guide/meta-tags
+[useHead]: https://unhead.unjs.io/usage/composables/use-head
+[vite static assets]: https://vite.dev/guide/assets.html
+[vite public directory]: https://vite.dev/guide/assets.html#the-public-directory
+
+# Static Assets 🍃
+
+<Iles/> relies on the powerful static asset handling provided by [Vite][vite static assets] to efficiently serve and manage static assets, such as CSS and images.
+
+> Place CSS, images, JavaScript modules, and other assets within the `src` directory for bundling and optimization by [Vite][vite public directory].
+
+## `useHead` Composable
+
+[useHead] can be used within the `setup` function or `<script setup>` of any Vue component.
+
+This powerful composable allows you to add external assets, such as `link` and `script` tags from CDNs, either to specific pages or to layouts to apply them across all pages.
+
+<AutoImported/>
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue' 
+  
+useHead({
+  htmlAttrs: { lang: 'en-US' },
+  bodyAttrs: { class: 'dark-mode', 'data-theme': 'light' },
+  link: [
+    {
+      href: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
+      rel: 'stylesheet',
+      integrity:
+        'sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH',
+      crossorigin: 'anonymous',
+    },
+  ],
+  style: [
+    {
+      innerHTML: 'p { color: #26b72b; }',
+    },
+  ],
+  noscript: [],
+  // useScript can also be used to load scripts
+  script: [
+    {
+      src: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js',
+      integrity:
+        'sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz',
+      crossorigin: 'anonymous',
+      tagPosition: 'bodyClose',
+    },
+    {
+      innerHTML: `;(() => {
+      const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches
+      const setting = localStorage.getItem('vueuse-color-scheme') || 'auto'
+      if (setting === 'dark' || (prefersDark && setting !== 'light'))
+        document.documentElement.classList.toggle('dark', true)
+    })()`,
+    },
+  ],
+})
+</script>
+```
+
+> `useHead` options support both static values and reactive variables, such as `ref`, `computed`, and `reactive`.
+
+> In addition to using the `useHead` composable, external static assets can be added through other methods discussed in [meta tags] page.
+
+## Public folder
+
+The `public` directory at your project root stores static files that do not require processing during the build. 
+
+Use the `public` folder for assets that:
+- Are not imported in source code (e.g., `robots.txt`).
+- Must retain their original file names.
+- Should be directly accessible via a URL (e.g., `/logo.png`).
+
+For example, an image at `publiclogo.png` can be referenced as:
+
+```html
+<img src="/logo.png" alt="Logo">
+```
+
+Files placed in the `public` are copied as-is to the final output (by default, `dist` folder), making it ideal for assets like images, fonts, favicons, `robots.txt`, and `manifest.webmanifest`.

--- a/docs/src/site.ts
+++ b/docs/src/site.ts
@@ -34,6 +34,7 @@ const site = {
         { text: 'Documents', link: '/guide/documents' },
         { text: 'Markdown', link: '/guide/markdown' },
         { text: 'Meta Tags', link: '/guide/meta-tags' },
+        { text: 'Static Assets', link: '/guide/static-assets' },
         { text: 'Hydration', link: '/guide/hydration' },
         { text: 'Frameworks', link: '/guide/frameworks' },
         { text: 'Client Scripts', link: '/guide/client-scripts' },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -24,5 +24,9 @@
   },
   "exclude": [
     "node_modules/cypress"
+  ],
+  "include": [
+    "components.d.ts",
+    "composables.d.ts"
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default antfu(
         usePage: 'readonly',
         useRoute: 'readonly',
         useHead: 'readonly',
+        useSeoMeta: 'readonly',
         definePageComponent: 'readonly',
       },
     },

--- a/packages/iles/src/client/index.ts
+++ b/packages/iles/src/client/index.ts
@@ -11,7 +11,7 @@ export { usePage, computedInPage } from './app/composables/pageData'
 export { useMDXComponents, provideMDXComponents } from './app/composables/mdxComponents'
 export { useVueRenderer } from './app/composables/vueRenderer'
 export { useRouter, useRoute } from 'vue-router'
-export { useHead } from '@unhead/vue'
+export { useHead, useSeoMeta } from '@unhead/vue'
 
 import type { ComponentOptionsWithoutProps, ComputedRef } from 'vue'
 import type { UserApp, GetStaticPaths, Document } from '../../types/shared'

--- a/packages/iles/src/node/plugin/composables.ts
+++ b/packages/iles/src/node/plugin/composables.ts
@@ -4,12 +4,13 @@ import { uniq } from './utils'
 import { parseImports } from './parse'
 
 const definitionRegex = /(?:function|const|let|var)\s+(definePageComponent|use(?:Page|Route|Head|Documents)\b)/g
-const composableUsageRegex = /\b(definePageComponent|use(?:Page|Route|Head|Documents))\s*\(/g
+const composableUsageRegex = /\b(definePageComponent|use(?:Page|Route|Head|SeoMeta|Documents))\s*\(/g
 
 const composables = [
   'definePageComponent',
   'useDocuments',
   'useHead',
+  'useSeoMeta',
   'usePage',
   'useRoute',
 ]

--- a/playground/the-vue-point/composables.d.ts
+++ b/playground/the-vue-point/composables.d.ts
@@ -5,6 +5,7 @@ declare global {
   const definePageComponent: typeof import('iles')['definePageComponent']
   const useDocuments: typeof import('iles')['useDocuments']
   const useHead: typeof import('iles')['useHead']
+  const useSeoMeta: typeof import('iles')['useSeoMeta']
   const usePage: typeof import('iles')['usePage']
   const useRoute: typeof import('iles')['useRoute']
 }

--- a/playground/the-vue-point/tsconfig.json
+++ b/playground/the-vue-point/tsconfig.json
@@ -19,5 +19,9 @@
     "paths": {
       "~/*": ["src/*"]
     }
-  }
+  },
+  "include": [
+    "components.d.ts",
+    "composables.d.ts"
+  ]
 }


### PR DESCRIPTION
This PR covers:

- feat: ✨ Support useSeoMeta from @unhead/vue, docs updated
- docs: 📝 Added a new static-assets page on importing external assets & using public folder