### PR TITLE
feat: ✨ Support user provider index.html

### DIFF
--- a/docs/iles.config.ts
+++ b/docs/iles.config.ts
@@ -5,6 +5,7 @@ import headings from '@islands/headings'
 import icons from '@islands/icons'
 import prism from '@islands/prism'
 import pwa from '@islands/pwa'
+import excerpt from '@islands/excerpt'
 import reactivityTransform from '@vue-macros/reactivity-transform/vite'
 
 import UnoCSS from 'unocss/vite'
@@ -16,6 +17,13 @@ const { title, description } = site
 
 export default defineConfig({
   siteUrl: 'https://iles-docs.netlify.app',
+
+  extendFrontmatter(frontmatter, filename) {
+    if (filename.includes('/recipes/') && !filename.includes('/recipes/index.vue')) {
+      frontmatter.layout = 'recipe'
+    }
+  },
+
   turbo: true,
   jsx: 'preact',
   debug: false,
@@ -23,6 +31,7 @@ export default defineConfig({
     headings(),
     icons(),
     prism(),
+    excerpt({ maxLength: 140 }),
     lastUpdated(),
     pwa({
       manifestFilename: 'pwa-manifest.json',

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@iconify-json/bx": "^1.1.10",
     "@iconify-json/heroicons-outline": "^1.1.10",
+    "@islands/excerpt": "workspace:*",
     "@islands/headings": "workspace:*",
     "@islands/icons": "workspace:*",
     "@islands/prism": "workspace:*",

--- a/docs/src/assets/recipes/vanilla-vue-to-iles/iles-build.jpg
+++ b/docs/src/assets/recipes/vanilla-vue-to-iles/iles-build.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd95cfa4259d4c352e868472d8a63516e4130c6947523ec1d51931911815d2d
+size 700450

--- a/docs/src/assets/recipes/vanilla-vue-to-iles/netlify-drop.jpg
+++ b/docs/src/assets/recipes/vanilla-vue-to-iles/netlify-drop.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bbed815a09aeb29e7c20351a8bb31d48377f3c687458c564aaea7458812b237
+size 542988

--- a/docs/src/assets/recipes/vanilla-vue-to-iles/netlify-preview.jpg
+++ b/docs/src/assets/recipes/vanilla-vue-to-iles/netlify-preview.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:279657e8885f175916642dca60440b1da4c63d4fa8753910f48ea07cdbdcac74
+size 496311

--- a/docs/src/assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg
+++ b/docs/src/assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee152bb2247906812853f8140c9651a1fed77519c8eb8ae2aad9ccaa03d2402a
+size 106137

--- a/docs/src/components/MetaTags.vue
+++ b/docs/src/components/MetaTags.vue
@@ -8,12 +8,32 @@ const { frontmatter, site } = usePage()
 let imageUrl = $computed(() => `${site.url}${frontmatter.image || bannerSrc}`)
 
 const isProd = import.meta.env.PROD
+
+const author = frontmatter.author || site.author
+const keywords = (frontmatter.tags || site.tags)?.join(', ')
+
+// Manage head meta with useSeoMeta
+useSeoMeta({
+  author,
+  keywords,
+
+  // Open Graph / Facebook / LinkedIn / Discord
+  ogType: 'website',
+  ogImage: imageUrl,
+  ogImageAlt: 'Îles',
+  ogLocale: 'en_US',
+
+  // Twitter (X)
+  twitterCard: 'summary_large_image',
+  twitterImage: imageUrl,
+  twitterImageAlt: 'Îles',
+  twitterSite: site.twitterHandle,
+  twitterCreator: site.authorHandle,
+})
 </script>
 
 <template>
   <Head>
-    <meta property="author" :content="site.author">
-    <meta property="keywords" :content="site.tags.join(', ')">
     <meta property="HandheldFriendly" content="True">
     <meta property="MobileOptimized" content="320">
     <meta http-equiv="cleartype" content="on">

--- a/docs/src/components/MetaTagsRecipe.vue
+++ b/docs/src/components/MetaTagsRecipe.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getPosts } from '~/logic/recipes'
+import { getImage } from '~/logic/utils';
+
+const posts = getPosts()
+const { page, site } = usePage()
+
+const currentIndex = computed(() =>
+  posts.value.findIndex((p) => p.href === page.value.href),
+)
+const post = computed(() => currentIndex.value > -1 ? posts.value[currentIndex.value] : posts.value[0])
+
+const title = computed(() => {
+  return post.value?.title
+})
+
+const ogImage = computed(() => {
+  const image = getImage(post.value?.image)
+  return `${site.url}${image}`
+})
+
+const author = computed(() => {
+  return post.value?.author
+})
+
+const twitterCreator = computed(() => {
+  return post.value?.twitter
+})
+
+useSeoMeta({
+  author,
+
+  // Open Graph / Facebook / LinkedIn / Discord
+  ogImage,
+  ogImageAlt: title,
+
+  // Twitter (X)
+  twitterImage: ogImage,
+  twitterImageAlt: title,
+  twitterCreator,
+})
+</script>
+
+<template>
+  <div></div>
+</template>

--- a/docs/src/components/PostDate.vue
+++ b/docs/src/components/PostDate.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineProps<{ date: string | Date }>()
+
+function toDate(date: string | Date) {
+  return date instanceof Date ? date : new Date(date)
+}
+
+function getDateTime(date: string | Date) {
+  return toDate(date).toISOString()
+}
+
+function formatDate(dateStr: string | Date) {
+  const date = toDate(dateStr)
+  date.setUTCHours(12)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <dl>
+    <dt class="sr-only">Published on</dt>
+    <dd>
+      <time :datetime="getDateTime(date)">{{ formatDate(date) }}</time>
+    </dd>
+  </dl>
+</template>

--- a/docs/src/components/ReloadPrompt.vue
+++ b/docs/src/components/ReloadPrompt.vue
@@ -1,5 +1,5 @@
 <script client:load lang="ts">
-import { OnLoadFn } from 'iles'
+import type { OnLoadFn } from 'iles'
 import { registerSW } from 'virtual:pwa-register'
 
 let refreshSW: ((reloadPage?: boolean) => Promise<void>) | undefined

--- a/docs/src/layouts/recipe.vue
+++ b/docs/src/layouts/recipe.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getPosts } from '~/logic/recipes'
+
+const posts = getPosts()
+const { page } = usePage()
+
+const currentIndex = computed(() =>
+  posts.value.findIndex((p) => p.href === page.value.href),
+)
+const post = computed(() => posts.value[currentIndex.value])
+</script>
+
+<template layout="default">
+  <h1 v-if="post">
+    {{ post.title }}
+  </h1>
+  <slot/>
+</template>
+
+<style scoped>
+.prose h1#introduction {
+    font-size: 1.5em;
+    font-weight: 700;
+    line-height: 1.3333333;
+    margin-bottom: 1em;
+    margin-top: 1.8em;
+}
+</style>

--- a/docs/src/logic/recipes.ts
+++ b/docs/src/logic/recipes.ts
@@ -1,0 +1,19 @@
+import type { Document, PageComponent } from 'iles'
+import { computed } from 'vue'
+
+export interface Post extends PageComponent {
+  date: Date
+  author: string
+  title: string
+  twitter: string
+  ogimage: string
+}
+
+function byDate(a: Document<Post>, b: Document<Post>) {
+  return Number(new Date(b.date)) - Number(new Date(a.date))
+}
+
+export function getPosts() {
+  const posts = useDocuments<Post>('~/pages/recipes/*.{md,mdx}')
+  return computed(() => posts.value.sort(byDate))
+}

--- a/docs/src/logic/recipes.ts
+++ b/docs/src/logic/recipes.ts
@@ -6,7 +6,7 @@ export interface Post extends PageComponent {
   author: string
   title: string
   twitter: string
-  ogimage: string
+  image: string
 }
 
 function byDate(a: Document<Post>, b: Document<Post>) {

--- a/docs/src/logic/utils.ts
+++ b/docs/src/logic/utils.ts
@@ -18,3 +18,10 @@ export function joinUrl (base: string, path: string): string {
   if (path.startsWith('#')) return path
   return `${base}${path.startsWith('/') ? path.slice(1) : path}`
 }
+
+export function getImage(fileName: string) {
+  const modules = import.meta.glob('@/assets/recipes/**/*.{jpg,png,svg}', { eager: true, import: 'default' })
+  const moduleKeys = Object.keys(modules)
+  const fileSrc = moduleKeys.find(key => key.endsWith(fileName))
+  return fileSrc ? modules[fileSrc] : ''
+}

--- a/docs/src/pages/config/index.mdx
+++ b/docs/src/pages/config/index.mdx
@@ -11,7 +11,6 @@ sidebar: auto
 [meta tags]: /guide/meta-tags
 [sitemap]: /guide/development#sitemap
 
-[shortcodes]: /guide/markdown#advanced-provide-components-shortcodes
 [deployment]: /guide/deployment 
 [VitePress]: /faqs#vitepress
 [turbo]: /guide/turbo
@@ -48,7 +47,7 @@ export default defineConfig({
 You may provide an `iles.config.ts` configuration file to customize settings
 related to markdown, component resolution, and other îles-specific features.
 
-You can leverage your IDE's intellisense with jsdoc type hints or use the `defineConfig` helper:
+You can leverage your IDE's intellisense by using the `defineConfig` helper:
 
 ```ts
 import { defineConfig } from 'iles'
@@ -155,83 +154,6 @@ When set, it is exposed as `site.url` and `site.canonical`.
 - **Default:** `true`
 
 Whether to output more information about islands and hydration in development.
-
-## Your App
-
-<Iles/> will pre-configure a Vue 3 app that will load any [pages] defined in the
-site.
-
-You may provide additional configuration in `src/app.ts`, and leverage
-intellisense by using the `defineApp` helper.
-
-```ts
-import { defineApp } from 'iles'
-
-export default defineApp({
-  head ({ frontmatter, site }) {
-    return {
-      meta: [
-        { property: 'author', content: site.author },
-        { property: 'keywords', content: computed(() => frontmatter.tags) },
-      ]
-    }
-  },
-  enhanceApp ({ app, head, router }) {
-    // Configure the app to add plugins.
-  },
-  router: {
-    scrollBehavior (current, previous, savedPosition) {
-      // Configure the scroll behavior
-    }, 
-  },
-})
-```
-
-### `head`
-
-- **Type:** `HeadObject | (context: AppContext) => HeadObject`
-
-Set the page title, meta tags, additional CSS, or scripts using [`@unhead/vue`][@unhead/vue].
-
-### `enhanceApp`
-
-- **Type:** `(context: AppContext) => Promise<void>`
-
-A hook where you can add plugins to the Vue app, or do anything else prior to
-the app being mounted.
-
-### `mdxComponents`
-
-- **Type:** `MDXComponents | (context: AppContext) => MDXComponents`
-
-Provide an object that [maps tag names in MDX to components][shortcodes] to render.
-
-```ts
-import { defineApp } from 'iles'
-import Image from '~/components/Image.vue'
-
-export default defineApp({
-  mdxComponents: {
-    b: 'strong',
-    img: Image,
-  },
-})
-```
-
-### `router`
-
-- **Type:** `RouterOptions`
-
-Configure [`vue-router`][vue-router] by providing options such as `scrollBehavior` and `linkActiveClass`.
-
-### `socialTags`
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Some social tags can be inferred from the <kbd>[site]</kbd>.
-
-Set it to `false` to avoid adding social tags such as `og:title` and `twitter:description`.
 
 ## `iles.config.ts` Example
 

--- a/docs/src/pages/dynamic/[section].vue
+++ b/docs/src/pages/dynamic/[section].vue
@@ -19,5 +19,5 @@ defineProps<{ message: string }>()
 <template>
   <h1>Dynamic Path Example</h1>
   <p v-html="message"/>
-  <p>Back to <a href="/guide/routing#getstaticpaths">Routing</a>.</p>
+  <p>Back to <a href="/guide/routing#generating-dynamic-routes">Routing</a>.</p>
 </template>

--- a/docs/src/pages/guide/development.mdx
+++ b/docs/src/pages/guide/development.mdx
@@ -10,6 +10,11 @@
 [siteUrl]: /config#siteurl
 [useDocuments]: /guide/documents
 [frameworks]: /guide/frameworks
+[head and meta tags]: /guide/meta-tags
+[discussion]: https://github.com/ElMassimo/iles/discussions/6#discussioncomment-1479755
+[`@unhead/vue`]: https://unhead.unjs.io/setup/vue/installation
+[shortcodes]: /guide/markdown#advanced-provide-components-shortcodes
+[vue-router]: https://next.router.vuejs.org/
 
 # Development 💻
 
@@ -35,8 +40,8 @@ In this section, we'll cover the basics to start building an <Iles/> application
   │    ├── about.vue
   │    └── index.mdx
   │
-  ├── <kbd><a href="/config#your-app">app.ts</a></kbd>
-  └── <kbd><a href="#site">site.ts</a></kbd></code>
+  ├── <kbd><a href="#site">site.ts</a></kbd>
+  └── <kbd><a href="#app-2">app.ts</a></kbd></code>
 </pre>
 </div>
 
@@ -55,6 +60,34 @@ import { useDark } from '~/logic/dark'
 Components in the <kbd>src/components</kbd> dir will be auto-imported on-demand, powered by [`unplugin-vue-components`](https://github.com/antfu/unplugin-vue-components).
 
 <Iles/> extends this so that you don't need to import components in [MDX files][mdx].
+
+## Layouts 📐
+
+Components in the <kbd>src/layouts</kbd> dir will be available as layouts, and they should provide a default `<slot/>`. 
+
+Pages may specify a layout using the `layout` property in frontmatter:
+
+```md
+---
+layout: post
+---
+```
+
+Layouts and Vue pages can also specify a parent layout using a `layout` attribute in the `template`:
+
+```vue
+<template layout="post">
+```
+
+> Layouts are optional; however, having a default layout is highly recommended.
+>
+> The `default` layout will be used for all pages unless specified.
+> 
+> Pages may opt-out by specifying `layout: false`
+
+<Tip warn>
+Layout files must be lowercase, as in `post.vue` or `default.vue`.
+</Tip>
 
 ## Pages 🛣
 
@@ -142,32 +175,6 @@ const posts = usePosts()
 </template>
 ```
 
-## Layouts 📐
-
-Components in the <kbd>src/layouts</kbd> dir will be available as layouts, and they should provide a default `<slot/>`.
-
-Pages may specify a layout using the `layout` property in frontmatter:
-
-```md
----
-layout: post
----
-```
-
-Layouts and Vue pages can also specify a parent layout using a `layout` attribute in the `template`:
-
-```vue
-<template layout="post">
-```
-
-> The `default` layout will be used for all pages unless specified.
->
-> Pages may opt-out by specifying `layout: false`
-
-<Tip warn>
-Layout files must be lowercase, as in `post.vue` or `default.vue`.
-</Tip>
-
 ## Site 🌐
 
 `src/site.ts` can be used to provide site-wide information such as `title`, `description`, etc.
@@ -183,10 +190,123 @@ export default {
 }
 ```
 
+It can be accessed as `$site` in component instances, or by using `usePage`.
+
+```vue
+<script setup>
+import { usePage } from 'iles' // not needed
+
+const { site } = usePage()
+</script>
+```
+
+It's also displayed in the page information in _Islands_ devtools.
+
+> Adding `src/site.ts` to your project is optional.
+> 
+> Alternatively, you can use composables from [`@unhead/vue`] to manage the [head and meta tags] of your page.
+
+## App 📱
+
+<Iles/> will pre-configure a Vue 3 shell that, during development, will load your site comprising of your [layouts](#layouts) and [pages](#pages) within it.
+
+`src/app.ts` can be used to provide additional configurations with the `defineApp` helper, allowing you to customize:
+- using `enhanceApp`, the development and build logic of this "outer" shell.
+- your site's head and meta tags, scroll behavior, etc.
+
+> This "outer" shell is loaded only during development and is not included in your built site.
+>
+> Adding `src/app.ts` to your project is optional.
+
+```ts
+import { defineApp } from 'iles'
+
+export default defineApp({
+  enhanceApp ({ app, head, router }) {
+    // Configure the "outer" shell to customize it's development/build logic
+  },
+  head ({ frontmatter, site }) {
+    return {
+      meta: [
+        { property: 'author', content: site.author },
+        { property: 'keywords', content: computed(() => frontmatter.tags) },
+      ]
+    }
+  },
+  router: {
+    scrollBehavior (current, previous, savedPosition) {
+      // Configure the scroll behavior
+    }, 
+  },
+  mdxComponents: {
+      // Options for tag mapping in MDX
+  },
+  socialTags: true // default
+})
+```
+
+### `enhanceApp` (Development only)
+
+- **Type:** `(context: AppContext) => void | Promise<void>`
+
+A hook where you can add additional development/build logic. See this [discussion] thread for few suggestions.
+
+### `head`
+
+- **Type:** `HeadObject | (context: AppContext) => HeadObject`
+
+Set the page title, meta tags, additional CSS, or scripts using [`@unhead/vue`].
+
+### `router`
+
+- **Type:** `RouterOptions`
+
+Configure [`vue-router`][vue-router] by providing options such as `scrollBehavior` and `linkActiveClass`.
+
+### `mdxComponents`
+
+- **Type:** `MDXComponents | (context: AppContext) => MDXComponents`
+
+Provide an object that [maps tag names in MDX to components][shortcodes] to render.
+
+```ts
+import { defineApp } from 'iles'
+import Image from '~/components/Image.vue'
+
+export default defineApp({
+  mdxComponents: {
+    b: 'strong',
+    img: Image,
+  },
+})
+```
+
+### `socialTags`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Some social tags can be inferred from the <kbd>[site](#site)</kbd>.
+
+Set it to `false` to avoid adding social tags such as `og:title` and `twitter:description`.
+
+## Devtools 🛠
+
+Page information is available in a debug panel, similar to VitePress, but you may also access an _Islands_ inspector in Vue devtools.
+
+This can be useful when debugging [islands hydration][hydration].
+
+## Iles Configuration ⚙️
+
+You may provide a `iles.config.ts` configuration file at your project root to customize the various îles-specific features.
+
+You may also provide a `vite.config.ts` configuration file (or use the `vite` key in `iles.config.ts`) to add vite plugins and customize the various vite-specific features.
+
 ### Sitemap 🗺
 
-A sitemap can be automatically generated for your site, all you need to do is
-configure <kbd>[siteUrl]</kbd>. That will also make it available as `site.url` and `site.canonical`.
+A sitemap can be automatically generated when you build your site, all you need to do is configure <kbd>[siteUrl]</kbd> in your `iles.config.ts` configuration file. 
+
+If configured, `siteUrl` will also make it available as `site.url` and `site.canonical`.
 
 ```ts
 import { defineConfig } from 'iles'
@@ -206,8 +326,4 @@ export default defineConfig({
 })
 ```
 
-## Devtools 🛠
-
-Page information is available in a debug panel, similar to VitePress, but you may also access an _Islands_ inspector in Vue devtools.
-
-This can be useful when debugging [islands hydration][hydration].
+> To learn more about further Iles and Vite configurations, refer to the [config] page.

--- a/docs/src/pages/guide/index.mdx
+++ b/docs/src/pages/guide/index.mdx
@@ -1,6 +1,7 @@
 [introduction]: /guide/introduction
 [configuration reference]: /config
 [starter]: https://github.com/ElMassimo/create-iles
+[recipes]: /recipes
 
 # Getting Started
 
@@ -40,16 +41,16 @@ npm add -D iles@latest # or pnpm, yarn, bun
 <kbd class="-ml-2">src/</kbd>
   ├── <kbd>pages/</kbd>
   │    ├── index.vue
-  │    └── about-us.md 
+  │    └── about.md 
   │    └── posts/
   │         ├── intro.mdx
-  │         └── goodbye.mdx
+  │         └── our-story.mdx
   
 </code>
 </pre>
 </div>
 
-Now, follow the next [usage](#usage) section.
+Now, follow the next [usage](#usage) section. Also explore the [recipes] page to learn through examples.
 
 ## Usage 🚀
 

--- a/docs/src/pages/guide/index.mdx
+++ b/docs/src/pages/guide/index.mdx
@@ -18,38 +18,86 @@ import stackblitzSrc from '/images/stackblitz.svg'
 
 ## Installation 💿
 
-Run the following command to create a new îles project.
+Run the following command to create a new îles project using the [starter] template. Then, follow the [usage](#usage) section.
 
 ```bash
 pnpm create iles@next # or npm or yarn
 ```
 
-The [starter] comes with Vue components and examples. Once you have installed
-all dependencies, give it a try by running <kbd>npm run dev</kbd> to start the
-development server.
+## Add îles to an Existing Project 💙 
 
-Alternatively, add `iles` to your `package.json` in an existing project.
+Add îles to your existing Vite-powered project using the following command:
+
+```bash
+npm add -D iles@latest # or pnpm, yarn, bun
+```
+
+îles serves pages from the `src/pages` folder, so ensure your pages are located there. They must be in one of the supported formats: `.vue`, `.md`, or `.mdx`. For example,
+
+<div class="language-tree">
+<pre class="code">
+<code>
+<kbd class="-ml-2">src/</kbd>
+  ├── <kbd>pages/</kbd>
+  │    ├── index.vue
+  │    └── about-us.md 
+  │    └── posts/
+  │         ├── intro.mdx
+  │         └── goodbye.mdx
+  
+</code>
+</pre>
+</div>
+
+Now, follow the next [usage](#usage) section.
 
 ## Usage 🚀
 
-The `iles` executable provides the following commands:
+Add the iles executable to the `scripts` section of your `package.json` if it's not already there.
+
+```json
+  "scripts": {
+    "dev": "iles dev",
+    "build": "iles build",
+    "preview": "iles preview --open",
+    "now": "npm run build && npm run preview"
+  },
+```
+
+From your terminal or integrated terminal of your editor (Visual Studio Code),
 
 - <kbd>iles dev</kbd>: Starts the development server
 - <kbd>iles build</kbd>: Creates a production build of the site
 - <kbd>iles preview</kbd>: Preview the site after building
 
-The following shortcuts are added by default when using the [starter]:
-
-```json
-  "scripts": {
-    "dev": "iles dev --open",
-    "build": "iles build",
-    "preview": "iles preview --open"
-  },
+```bash
+npm install # or pnpm, yarn, bun
 ```
 
-- <kbd>npm run dev</kbd>: Starts the development server
-- <kbd>npm run build</kbd>: Creates a production build of the site
-- <kbd>npm run preview</kbd>: Preview the site after building
+### Start your development server:
+
+```bash
+npm run dev # or pnpm, yarn, bun
+```
+
+### Build for production:
+
+Generates the final output (by default, `dist` folder).
+
+```bash
+npm run build # or pnpm, yarn, bun
+```
+
+### Preview your site locally after building:
+
+```bash
+npm run preview # or pnpm, yarn, bun
+```
+
+### Alternatively, Build and Preview with a single command:
+
+```bash
+npm run now # or pnpm, yarn, bun
+```
 
 <Contact/>

--- a/docs/src/pages/guide/markdown.mdx
+++ b/docs/src/pages/guide/markdown.mdx
@@ -120,7 +120,7 @@ imported if they are placed in the [components] dir.
 
 ```vue
 <script setup>
-import Acknowledgements from '~/components/Acknowledgements.mdx' // not needed
+import Acknowledgements from '~/components/Acknowledgements.mdx' // not required
 </script>
 
 <template>
@@ -132,7 +132,7 @@ They can also be used in MDX files as components, which is the easiest way to
 reuse footers or sections that are repeated across documents.
 
 ```jsx
-import Acknowledgements from '~/components/Acknowledgements.mdx' // not needed
+import Acknowledgements from '~/components/Acknowledgements.mdx' // not required
 
 And _without_ further ado:
 

--- a/docs/src/pages/guide/meta-tags.mdx
+++ b/docs/src/pages/guide/meta-tags.mdx
@@ -1,6 +1,8 @@
-[@unhead/vue]: https://github.com/@unhead/vue
-[app]: /config#your-app
-[useHead]: https://github.com/@unhead/vue#api
+[@unhead/vue]: https://unhead.unjs.io/setup/vue/installation
+[app]: /guide/development#app-2
+[useHead]: https://unhead.unjs.io/usage/composables/use-head
+[useSeoMeta]: https://unhead.unjs.io/usage/composables/use-seo-meta
+[Head]: https://unhead.unjs.io/setup/vue/components
 [site]: /guide/development#site
 [frontmatter]: /guide/development#pages
 

--- a/docs/src/pages/recipes/index.vue
+++ b/docs/src/pages/recipes/index.vue
@@ -17,7 +17,7 @@ const recipes = getPosts()
       <article v-for="recipe in recipes" :key="recipe.href" class="dark:bg-[var(--bg-highlight)] overflow-hidden rounded-lg shadow-lg">
         <a class="!no-underline hover:!text-[var(--fc-intense)] active:!text-[var(--fc-intense)]" :href="recipe.href">
           <span class="w-full h-48 object-cover">
-            <Image :src="getImage(recipe.ogimage)" alt=""/>
+            <Image :src="getImage(recipe.image)" alt=""/>
           </span>
           <div class="px-6 pb-6">
             <h2>{{ recipe.title }}</h2>

--- a/docs/src/pages/recipes/index.vue
+++ b/docs/src/pages/recipes/index.vue
@@ -1,0 +1,35 @@
+<page> 
+    title: Recipes
+    alias: ['/recipes']
+</page>
+ 
+<script setup lang="ts">
+import { getPosts } from '~/logic/recipes'
+import { getImage } from '~/logic/utils';
+const recipes = getPosts()
+</script>
+ 
+<template layout="default"> 
+  <section>
+    <h1>Recipes</h1>
+    <p>Îles recipes are concise, focused guides covering various use cases with step-by-step instructions. They offer a great way to learn Îles while enhancing your project with new features or functionality through clear, practical examples.</p>
+    <div class="gap-8 grid grid-cols-1 lg:grid-cols-2 max-w-7xl mx-auto">
+      <article v-for="recipe in recipes" :key="recipe.href" class="dark:bg-[var(--bg-highlight)] overflow-hidden rounded-lg shadow-lg">
+        <a class="!no-underline hover:!text-[var(--fc-intense)] active:!text-[var(--fc-intense)]" :href="recipe.href">
+          <span class="w-full h-48 object-cover">
+            <Image :src="getImage(recipe.ogimage)" alt=""/>
+          </span>
+          <div class="px-6 pb-6">
+            <h2>{{ recipe.title }}</h2>
+            <PostDate class="text-sm text-primary-600 dark:text-primary-200 font-medium mb-2 block" :date="recipe.frontmatter.date">
+              {{ new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) }}
+            </PostDate>
+            <component :is="recipe" class="text-gray-600 dark:text-gray-300 mb-4" excerpt>Discover a delightful blend of Mediterranean flavors in this recipe, featuring sun-dried tomatoes, kalamata olives, and aromatic herbs, all tossed with al dente pasta and finished with crumbled feta cheese.</component>
+            <a class="link inline-block" :href="recipe.href">Read more →</a>
+          </div></a>
+      </article>
+    </div>
+  </section>     
+</template>
+ 
+<style scoped></style>

--- a/docs/src/pages/recipes/vanilla-vue-to-iles.mdx
+++ b/docs/src/pages/recipes/vanilla-vue-to-iles.mdx
@@ -3,9 +3,11 @@ date: 2025-01-23
 author: Ahmed Kaja
 title: 'Vanilla Vue to îles'
 twitter: '@techakayy'
-# ogimage is relative to src/assets folder
-ogimage: 'assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg'
+# image is relative to src/assets folder
+image: 'assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg'
 ---
+{/* This component overrides MetaTags.vue */}
+<MetaTagsRecipe/>
 
 [vite index html]: https://vite.dev/guide/#index-html-and-project-root
 [static assets]: /guide/static-assets

--- a/docs/src/pages/recipes/vanilla-vue-to-iles.mdx
+++ b/docs/src/pages/recipes/vanilla-vue-to-iles.mdx
@@ -1,0 +1,271 @@
+---
+date: 2025-01-23
+author: Ahmed Kaja
+title: 'Vanilla Vue to îles'
+twitter: '@techakayy'
+# ogimage is relative to src/assets folder
+ogimage: 'assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg'
+---
+
+[vite index html]: https://vite.dev/guide/#index-html-and-project-root
+[static assets]: /guide/static-assets
+[usage]: /guide#usage
+[frameworks]: /guide/frameworks
+[hydration]: /guide/hydration
+[VitePress]: https://vitepress.dev/
+[Vite-SSG]: https://github.com/antfu-collective/vite-ssg
+[project structure]: /guide/development
+[frameworks]: /guide/frameworks
+[client directives]: /guide/hydration
+[client scripts]: /guide/client-scripts
+
+New to Vue? 💚 Scaffold a new Vue project using the following command. Then, convert it into an îles project.
+
+```bash
+npm create vue@latest # or pnpm, yarn, bun
+```
+
+The scaffolded Vanilla Vue project is powered by Vite and serves as a great example of basic Vue concepts, including the Single File Component structure, props, and slots. It's a Single-Page Application (SPA) with snappy navigation, powered by `vue-router`.
+
+# Introduction
+
+In this guide, we will convert this SPA into a static Multi-Page Application (MPA) site. Once completed, we will build and deploy static HTML pages with `zero` JavaScript. 
+
+The goal is to understand the concepts by migrating between the two flavors (SPA and MPA).
+
+<Iles/> builds static Multi-Page Application (MPA) sites. Checkout [Vitepress] and [Vite-SSG] to build static Single Page Application (SPA) sites.
+
+<Image src='@/assets/recipes/vanilla-vue-to-iles/vanilla-vue.jpg' alt="Vanilla Vue App" wide narrow={false} />
+
+## 1. Install îles
+
+Before installing, since îles pre-includes `vite`, remove `"vite": "6.x.x"` from your `package.json` to prevent multiple Vite installations, which could cause TypeScript issues.
+
+```bash
+npm add -D iles@latest # or pnpm, yarn, bun
+```
+
+Once completed, start your development server with the following CLI command. Alternatively, refer to the [usage] to add commands to your `package.json`.
+
+```bash
+npx iles dev # or pnpm, yarn, bun
+```
+
+## 2. Remove `index.html` or Its Entry Files
+
+The `index.html` entry page in your project root does not load any other assets apart from the entry file (`/src/main.ts`). Therefore, either remove it or delete the below script tag shown below.
+
+```html
+<script type="module" src="/src/main.ts"></script>
+```
+
+If you want to retain this `index.html` to add external assets from CDN, refer to the [static assets] page for details. Additionally, remove the `title` and `meta` tags in your custom `index.html` as Îles will add them automatically. 
+
+## 3. Add `iles.config.ts`
+
+Create an `iles.config.ts` file at your project root as shown below.
+
+```ts
+import { defineConfig } from 'iles'
+
+export default defineConfig({
+  siteUrl: 'https://myawesomeidea.com', // Your site URL
+  modules: [
+    // Add iles modules here, refer to Modules page
+  ],
+})
+```
+
+### Existing `vite.config.ts`
+
+The `vite.config.ts` file in your project root, you can either keep it or migrate its configuration into the `vite` key of `iles.config.ts` as shown below.
+
+<b>Important</b> Remove `@vitejs/plugin-vue` (Vite plugin for Vue)
+
+- <b>Keeping</b> `vite.config.ts`: Remove `@vitejs/plugin-vue` from its plugins array to avoid conflicts, as îles already includes it.
+
+- <b>Migrating</b> to `iles.config.ts`: Do not include `@vitejs/plugin-vue` in the migration. After migrating, remove `vite.config.ts` file from your project root. You can also skip migrating `resolve.alias` object, as Îles already covers that.
+
+```ts
+import { defineConfig } from 'iles'
+import vueDevTools from 'vite-plugin-vue-devtools'
+
+export default defineConfig({
+  siteUrl: 'https://myawesomeidea.com', // Your site URL
+  modules: [
+    // Add iles modules here, refer to Modules page
+  ],
+  vite: {
+    // Vite configuration goes here
+    plugins: [
+      // Add vite plugins here
+      vueDevTools(),
+    ]
+  }
+})
+```
+
+## 4. Add `app.ts`
+
+- Create an `src/app.ts` file as shown below. 
+- Copy `import './assets/main.css'` from your entry file `src/main.ts` into `app.ts`.
+- Remove or archive `main.ts` as it's not required anymore.
+
+```ts
+import '@/assets/main.css' // from `src/main.ts`
+import { defineApp } from 'iles'
+
+export default defineApp({
+  head ({ frontmatter, site }) {
+    return {
+      meta: [
+        { property: 'author', content: site.author },
+        { property: 'keywords', content: () => frontmatter.tags },
+      ],
+      htmlAttrs: { lang: 'en-US' },
+      bodyAttrs: {},
+    }
+  },
+})
+```
+
+## 5. Add `site.ts`
+
+Create an `src/site.ts` file as shown below:
+
+```ts
+export default {
+  title: 'Cafe Tee Kaapi',
+  description: 'Sip, Savor, and Spark Ideas!',
+}
+```
+
+## 6. `App.vue` to Default Layout
+
+- Create a new `src/layouts` folder, copy `App.vue` into it, and rename it to `default.vue`. 
+- Convert the `RouterLink` components to simple anchor tags, change the `to` prop to `href`.
+- Replace `<RouterView />` with `<slot/>`. This slot will load all your pages in your site. 
+
+Your `layouts/default.vue` will look like the below.
+
+```vue
+<script setup lang="ts">
+import HelloWorld from '@/components/HelloWorld.vue'
+</script>
+
+<template>
+  <header>
+    <img alt="Vue logo" class="logo" src="@/assets/logo.svg" 
+      width="125" height="125" />
+
+    <div class="wrapper">
+      <HelloWorld msg="You did it!" />
+
+      <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <slot />
+</template>
+
+<style>
+/* Existing styles */
+</style>
+```
+
+> Remove the `src/router` folder, as îles uses file-based routing. Any custom logic might need to be migrated to `app.ts`, your default layout, or one of your interactive Islands.
+
+## 7. View to Pages
+
+îles uses the `pages` and `layouts` folder conventions with filenames in kebab-case.
+- Rename the folder that contains all your pages (for example, `src/views`) to `src/pages`.
+- Rename the `.vue` file of your home page (for example, `HomeView.vue`) to `index.vue`.
+- Rename the `.vue` files of your other pages to follow kebab-case. For example, `AboutView.vue` could be renamed to `about.vue`
+- Add a `<page></page>` tag at the top of your page files and add a `title` and `description` as `frontmatter`. 
+
+Your `index.vue` page will look like the below.
+
+```vue
+<page>
+  title: Home
+  description: First Coffee, Then Conquer!
+</page>
+
+<script setup lang="ts">
+import TheWelcome from '../components/TheWelcome.vue'
+</script>
+
+<template>
+  <main>
+    <TheWelcome />
+  </main>
+</template>
+```
+
+## 8. Add a New Page
+
+îles provides excellent support for authoring your pages with markdown (`.md`, `.mdx`). 
+
+- Create a third page `src/pages/our-story.md` as shown below. 
+- Add a third anchor tag for `our-story` under `nav` in `layouts/default.vue`. 
+
+```md
+---
+title: Our Story
+description: Crafting Memories, Brewing History!
+---
+
+# This is our story page
+```
+
+```vue
+<!-- within layouts/default.vue  -->
+<nav>
+  <a href="/">Home</a>
+  <a href="/about">About</a>
+  <a href="/our-story">Our Story</a>
+</nav>
+```
+
+## 9. Build Your Site
+
+- Stop your development server by pressing `Cmd/Ctrl+C` in your terminal.
+- Use the following command to build your site.
+- Alternatively, refer to the [usage] to add commands to your `package.json`.
+
+```bash
+npx iles build # or pnpm, yarn, bun
+```
+
+Check the `dist` folder to see the three HTML pages generated along with their CSS assets. 
+
+Note that `zero` JavaScript is shipped. To add interactive Islands, refer to the [frameworks] and [hydration] pages to learn about hydration client scripts.
+
+<Image src='@/assets/recipes/vanilla-vue-to-iles/iles-build.jpg' alt="Iles Build" wide narrow={false} />
+
+## 10. Preview Your Site
+
+- Use the following command to preview your site in your local browser.
+- Alternatively, drag and drop the `dist` folder from your Finder or file-explorer into [Netlify Drop](https://app.netlify.com/drop) for instant deployment and preview.
+- Test your production site by navigating through the different pages.
+
+```bash
+npx iles preview # or pnpm, yarn, bun
+```
+
+<Image src='@/assets/recipes/vanilla-vue-to-iles/netlify-drop.jpg' alt="Netlify Drop" wide narrow={false} />
+
+If you used Netlify Drop, once deployment has completed successfully, click the `Open Production deploy` button to preview your site.
+
+<Image src='@/assets/recipes/vanilla-vue-to-iles/netlify-preview.jpg' alt="Netlify Preview" wide narrow={false} />
+
+## What's Next
+
+Now, learn about the [project structure] to familiarize yourself with the various conventions and best practices in îles.
+
+To add interactive îslands to your static Îles site, explore using [frameworks], [client directives], and [client scripts].
+
+Well Done. Have a joyful Îles experience!

--- a/docs/src/site.ts
+++ b/docs/src/site.ts
@@ -21,6 +21,7 @@ const site = {
     { text: 'Guide', link: '/guide' },
     { text: 'Config', link: '/config' },
     { text: 'FAQs', link: '/faqs' },
+    { text: 'Recipes', link: '/recipes' },
   ],
 
   sidebar: [
@@ -54,6 +55,21 @@ const site = {
         { text: 'Troubleshooting', link: '/faqs/troubleshooting' },
       ],
     },
+    {
+      text: 'Recipes',
+      link: '/recipes',
+      children: [
+        {
+          text: 'Recipes',
+          link: '/recipes'
+        },
+        {
+          text: 'Vanilla Vue to Îles',
+          link: '/recipes/vanilla-vue-to-iles'
+        }
+      ],
+    },    
+    
   ],
 }
 

--- a/packages/iles/package.json
+++ b/packages/iles/package.json
@@ -81,6 +81,7 @@
     "mico-spinner": "^1.4.0",
     "micromatch": "^4.0.7",
     "minimist": "^1.2.8",
+    "parse5": "^7.2.1",
     "pathe": "^1.1.2",
     "picocolors": "^1.0.1",
     "unist-util-visit": "^5.0.0",

--- a/packages/iles/src/node/plugin/html.ts
+++ b/packages/iles/src/node/plugin/html.ts
@@ -1,0 +1,363 @@
+// Inspired by Vite's html parsing with parse5 https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/html.ts
+
+import { promises as fs } from 'fs'
+import { exists } from './utils'
+import { resolve } from 'pathe'
+
+import type { AppConfig } from '../shared'
+import { ILES_APP_ENTRY } from '../constants'
+
+import type { DefaultTreeAdapterMap, ParserError, Token } from 'parse5'
+import type {
+  RollupError,
+} from 'rollup'
+
+function nodeIsElement (
+  node: DefaultTreeAdapterMap['node'],
+): node is DefaultTreeAdapterMap['element'] {
+  return node.nodeName[0] !== '#'
+}
+
+function traverseNodes (
+  node: DefaultTreeAdapterMap['node'],
+  visitor: (node: DefaultTreeAdapterMap['node']) => void,
+) {
+  if (node.nodeName === 'template') {
+    node = (node as DefaultTreeAdapterMap['template']).content
+  }
+  visitor(node)
+  if (
+    nodeIsElement(node)
+    || node.nodeName === '#document'
+    || node.nodeName === '#document-fragment'
+  ) {
+    node.childNodes.forEach((childNode) => traverseNodes(childNode, visitor))
+  }
+}
+
+const splitRE = /\r?\n/g
+
+const range: number = 2
+
+interface Pos {
+  /** 1-based */
+  line: number
+  /** 0-based */
+  column: number
+}
+
+function posToNumber (source: string, pos: number | Pos): number {
+  if (typeof pos === 'number') return pos
+  const lines = source.split(splitRE)
+  const { line, column } = pos
+  let start = 0
+  for (let i = 0; i < line - 1 && i < lines.length; i++) {
+    start += lines[i].length + 1
+  }
+  return start + column
+}
+
+function generateCodeFrame (
+  source: string,
+  start: number | Pos = 0,
+  end?: number | Pos,
+): string {
+  start = Math.max(posToNumber(source, start), 0)
+  end = Math.min(
+    end !== undefined ? posToNumber(source, end) : start,
+    source.length,
+  )
+  const lines = source.split(splitRE)
+  let count = 0
+  const res: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    count += lines[i].length
+    if (count >= start) {
+      for (let j = i - range; j <= i + range || end > count; j++) {
+        if (j < 0 || j >= lines.length) continue
+        const line = j + 1
+        res.push(
+          `${line}${' '.repeat(Math.max(3 - String(line).length, 0))}|  ${lines[j]
+          }`,
+        )
+        const lineLength = lines[j].length
+        if (j === i) {
+          // push underline
+          const pad = Math.max(start - (count - lineLength), 0)
+          const length = Math.max(
+            1,
+            end > count ? lineLength - pad : end - start,
+          )
+          res.push(`   |  ${' '.repeat(pad)}${'^'.repeat(length)}`)
+        }
+        else if (j > i) {
+          if (end > count) {
+            const length = Math.max(Math.min(end - count, lineLength), 1)
+            res.push(`   |  ${'^'.repeat(length)}`)
+          }
+          count += lineLength + 1
+        }
+      }
+      break
+    }
+    count++
+  }
+  return res.join('\n')
+}
+
+/**
+ * Format parse5 @type {ParserError} to @type {RollupError}
+ */
+function formatParseError (parserError: ParserError, id: string, html: string) {
+  const formattedError = {
+    code: parserError.code,
+    message: `parse5 error code ${parserError.code}`,
+    frame: generateCodeFrame(
+      html,
+      parserError.startOffset,
+      parserError.endOffset,
+    ),
+    loc: {
+      file: id,
+      line: parserError.startLine,
+      column: parserError.startCol,
+    },
+  } satisfies RollupError
+  return formattedError
+}
+
+function handleParseError (
+  parserError: ParserError,
+  html: string,
+  filePath: string,
+) {
+  switch (parserError.code) {
+    case 'missing-doctype':
+      // ignore missing DOCTYPE
+      return
+    case 'abandoned-head-element-child':
+      // Accept elements without closing tag in <head>
+      return
+    case 'duplicate-attribute':
+      // Accept duplicate attributes #5966
+      // The first attribute is used, browsers silently ignore duplicates
+      return
+    case 'non-void-html-element-start-tag-with-trailing-solidus':
+      // Allow self closing on non-void elements #10439
+      return
+    case 'unexpected-question-mark-instead-of-tag-name':
+      // Allow <?xml> declaration and <?> empty elements
+      // lit generates <?>: https://github.com/lit/lit/issues/2470
+      return
+  }
+  const parseError = formatParseError(parserError, filePath, html)
+  throw new Error(
+    `Unable to parse HTML; ${parseError.message}\n`
+    + ` at ${parseError.loc.file}:${parseError.loc.line}:${parseError.loc.column}\n`
+    + `${parseError.frame}`,
+  )
+}
+
+async function traverseHtml (
+  html: string,
+  filePath: string,
+  visitor: (node: DefaultTreeAdapterMap['node']) => void,
+): Promise<void> {
+  // lazy load compiler
+  const { parse } = await import('parse5')
+  const ast = parse(html, {
+    scriptingEnabled: false, // parse inside <noscript>
+    sourceCodeLocationInfo: true,
+    onParseError: (e: ParserError) => {
+      handleParseError(e, html, filePath)
+    },
+  })
+  traverseNodes(ast, visitor)
+}
+
+function getScriptInfo (node: DefaultTreeAdapterMap['element']): {
+  src: Token.Attribute | undefined
+  srcSourceCodeLocation: Token.Location | undefined
+  isModule: boolean
+  isAsync: boolean
+  isIgnored: boolean
+} {
+  let src: Token.Attribute | undefined
+  let srcSourceCodeLocation: Token.Location | undefined
+  let isModule = false
+  let isAsync = false
+  let isIgnored = false
+  for (const p of node.attrs) {
+    if (p.prefix !== undefined) continue
+    if (p.name === 'src') {
+      if (!src) {
+        src = p
+        srcSourceCodeLocation = node.sourceCodeLocation?.attrs!.src
+      }
+    }
+    else if (p.name === 'type' && p.value && p.value === 'module') {
+      isModule = true
+    }
+    else if (p.name === 'async') {
+      isAsync = true
+    }
+    else if (p.name === 'vite-ignore') {
+      isIgnored = true
+    }
+  }
+  return { src, srcSourceCodeLocation, isModule, isAsync, isIgnored }
+}
+
+interface HtmlTagDescriptor {
+  tag: string
+  attrs?: Record<string, string | boolean | undefined>
+  children?: string | HtmlTagDescriptor[]
+  /**
+   * default: 'head-prepend'
+   */
+  injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend'
+}
+
+const unaryTags = new Set(['link', 'meta', 'base'])
+
+function serializeTag (
+  { tag, attrs, children }: HtmlTagDescriptor,
+  indent: string = '',
+): string {
+  if (unaryTags.has(tag)) {
+    return `<${tag}${serializeAttrs(attrs)}>`
+  }
+  else {
+    return `<${tag}${serializeAttrs(attrs)}>${serializeTags(
+      children,
+      incrementIndent(indent),
+    )}</${tag}>`
+  }
+}
+
+function serializeTags (
+  tags: HtmlTagDescriptor['children'],
+  indent: string = '',
+): string {
+  if (typeof tags === 'string') {
+    return tags
+  }
+  else if (tags && tags.length) {
+    return tags.map((tag) => `${indent}${serializeTag(tag, indent)}\n`).join('')
+  }
+  return ''
+}
+
+const escapeHtmlReplaceMap = {
+  '&': '&amp;',
+  '\'': '&#x27;',
+  '`': '&#x60;',
+  '"': '&quot;',
+  '<': '&lt;',
+  '>': '&gt;',
+}
+
+function escapeHtml (string: string | undefined): string {
+  // @ts-ignore
+  return string.replace(/[&'`"<>]/g, (match) => escapeHtmlReplaceMap[match])
+}
+
+
+function serializeAttrs (attrs: HtmlTagDescriptor['attrs']): string {
+  let res = ''
+  for (const key in attrs) {
+    if (typeof attrs[key] === 'boolean') {
+      res += attrs[key] ? ` ${key}` : ``
+    }
+    else {
+      res += ` ${key}="${escapeHtml(attrs[key])}"`
+    }
+  }
+  return res
+}
+
+function incrementIndent (indent: string = '') {
+  return `${indent}${indent[0] === '\t' ? '\t' : '  '}`
+}
+
+// User provided index.html
+export async function getUserShell (config: AppConfig, html: string = ''): Promise<{
+  userShellPath: string
+  userShell: string
+  isValidUserShell: boolean
+  errorMsgUserShell: string
+}> {
+
+  const userShellPath = resolve(config.root, 'index.html')
+
+  let userShell = html
+
+  let ilesDevShellExists = false; let divAppForShell = false
+
+  if (!userShell) {
+    if (await exists(userShellPath)) {
+      userShell = await fs.readFile(userShellPath, 'utf-8')
+    }
+    else {
+      userShell = `<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>`
+    }
+  }
+
+  await traverseHtml(userShell, userShellPath, (node) => {
+    if (!nodeIsElement(node)) {
+      return
+    }
+
+    // script tags
+    if (node.nodeName === 'script') {
+      const { src } = getScriptInfo(node)
+      if (src?.value === ILES_APP_ENTRY) {
+        ilesDevShellExists = true
+      }
+    }
+
+    if (node.nodeName === 'div') {
+      const nonTextCommentChildNodes = node.childNodes.filter(node => node.nodeName !== '#text' && node.nodeName !== '#comment')
+      if (!nonTextCommentChildNodes.length) {
+        for (const attr of node.attrs) {
+          if (attr.name === 'id' && attr.value === 'app') {
+            divAppForShell = true
+            break;
+          }
+        }
+      }
+    }
+  })
+
+  let errorMsgUserShell = ''; let isValidUserShell = true
+
+  if (!ilesDevShellExists) {
+    // Inject iles dev shell if it doesn't exist
+    const ilesDevShell = '<script type="module" src="/@iles-entry"></script>';
+    const bodyCloseTag = '</body>';
+    return await getUserShell(config, userShell.replace(bodyCloseTag, `${ilesDevShell}\n${bodyCloseTag}`))
+  }
+
+  if (!divAppForShell) {
+    errorMsgUserShell = `[îles] index.html doesn't contain an div#app placeholder to load shell. Add <div id="app"></div> inside body.`
+    isValidUserShell = false
+  }
+
+  if (!isValidUserShell) {
+    throw new Error(errorMsgUserShell)
+  }
+
+  return {
+    userShellPath,
+    userShell,
+    isValidUserShell,
+    errorMsgUserShell,
+  }
+}

--- a/packages/iles/src/node/plugin/plugin.ts
+++ b/packages/iles/src/node/plugin/plugin.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs'
 import { basename, resolve, relative } from 'pathe'
 import type { PluginOption, ResolvedConfig, ViteDevServer } from 'vite'
 import { transformWithEsbuild } from 'vite'
+import { getUserShell } from './html';
 
 import MagicString from 'magic-string'
 
@@ -17,19 +18,19 @@ import { detectMDXComponents } from './markdown'
 import { autoImportComposables, writeComposablesDTS } from './composables'
 import documents from './documents'
 
-function isMarkdown (path: string) {
+function isMarkdown(path: string) {
   return path.endsWith('.mdx') || path.endsWith('.md')
 }
 
-function isSFCMain (path: string, query: Record<string, any>) {
+function isSFCMain(path: string, query: Record<string, any>) {
   return path.endsWith('.vue') && query.vue === undefined
 }
 
-function isVueScript (path: string, query: Record<string, any>) {
+function isVueScript(path: string, query: Record<string, any>) {
   return path.endsWith('.vue') && (!query.type || query.type === 'script')
 }
 
-async function transformUserFile (path: string) {
+async function transformUserFile(path: string) {
   return await exists(path)
     ? await transformWithEsbuild(await fs.readFile(path, 'utf-8'), path, { sourcemap: false })
     : { code: 'export default {}' }
@@ -38,7 +39,7 @@ async function transformUserFile (path: string) {
 const templateLayoutRegex = /<template.*?\slayout=\s*['"](\w+)['"].*?>/
 
 // Public: Configures MDX, Vue, Components, and Islands plugins.
-export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
+export default function IslandsPlugins(appConfig: AppConfig): PluginOption[] {
   debug.config(appConfig)
 
   let base: ResolvedConfig['base']
@@ -53,7 +54,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
 
   const plugins = appConfig.namedPlugins
 
-  function isLayout (path: string) {
+  function isLayout(path: string) {
     return path.includes(appConfig.layoutsDir)
   }
 
@@ -61,7 +62,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
     {
       name: 'iles',
       enforce: 'pre',
-      async configResolved (config) {
+      async configResolved(config) {
         if (base) return
         base = config.base
         root = config.root
@@ -74,7 +75,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
         const result = await transformUserFile(appPath)
         detectMDXComponents(result.code, appConfig, undefined)
       },
-      async resolveId (id) {
+      async resolveId(id) {
         if (id === ILES_APP_ENTRY)
           return APP_PATH
 
@@ -87,7 +88,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
         // Prevent import analysis failure if the default layout doesn't exist.
         if (id === defaultLayoutPath) return resolve(root, id.slice(1))
       },
-      async load (id) {
+      async load(id) {
         if (id === APP_CONFIG_REQUEST_PATH) {
           const { base, debug, jsx, ssg: { sitemap }, siteUrl, markdown: { overrideElements = [] } } = appConfig
           const clientConfig: AppClientConfig = { base, debug, root, jsx, sitemap, siteUrl, overrideElements }
@@ -112,23 +113,39 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
         if ((isBuild || process.env.VITEST) && id.includes(defaultLayoutPath) && !await exists(resolve(root, defaultLayoutPath.slice(1))))
           return '<template><slot/></template>'
       },
-      transform (code, id) {
+      transform(code, id) {
         if (id === APP_COMPONENT_PATH && !isBuild && appConfig.debug)
           return code.replace('const DebugPanel = () => null', () => `import DebugPanel from '${DEBUG_COMPONENT_PATH}'`)
       },
-      handleHotUpdate ({ file, server }) {
+      handleHotUpdate({ file, server }) {
         if (file === appPath) return [server.moduleGraph.getModuleById(USER_APP_REQUEST_PATH)!]
         if (file === sitePath) return [server.moduleGraph.getModuleById(USER_SITE_REQUEST_PATH)!]
       },
-      configureServer (devServer) {
+      configureServer(devServer) {
         server = devServer
         return configureMiddleware(appConfig, server, defaultLayoutPath)
       },
+      async transformIndexHtml(html, ctx) {
+        const indexHtmlFilePath = resolve(root, 'index.html')
+        if (ctx.filename === indexHtmlFilePath) {
+          // Validate user provided index.html
+          const {
+            userShell,
+            isValidUserShell,
+            errorMsgUserShell,
+          } = await getUserShell(appConfig, html)
+
+          if (!isValidUserShell) {
+            throw new Error(errorMsgUserShell)
+          }
+          return userShell
+        }
+      }
     },
     {
       name: 'iles:detect-islands-in-vue',
       enforce: 'pre',
-      async transform (code, id) {
+      async transform(code, id) {
         const { path, query } = parseId(id)
 
         if (query.vue !== undefined && query.type === 'script-client')
@@ -141,7 +158,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
     {
       name: 'iles:layouts',
       enforce: 'pre',
-      transform (code, id) {
+      transform(code, id) {
         const { path, query } = parseId(id)
         if (!isSFCMain(path, query) || !isLayout(path)) return
         const layoutName = code.match(templateLayoutRegex)?.[1] || false
@@ -159,7 +176,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
     {
       name: 'iles:composables',
       enforce: 'post',
-      async transform (code, id) {
+      async transform(code, id) {
         if (!id.startsWith(appConfig.srcDir)) return
 
         const { path, query } = parseId(id)
@@ -171,7 +188,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
     {
       name: 'iles:page-data',
       enforce: 'post',
-      async transform (code, id, options) {
+      async transform(code, id, options) {
         const { path, query } = parseId(id)
         const isMdx = isMarkdown(path)
         if (!isMdx && !isVueScript(path, query)) return
@@ -231,7 +248,7 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
       apply: 'serve',
       enforce: 'post',
       // Force a refresh for all page computed properties.
-      async transform (code, id) {
+      async transform(code, id) {
         const { path } = parseId(id)
         if (isLayout(path) || plugins.pages.api.isPage(path)) {
           return `${code}
@@ -243,7 +260,7 @@ import.meta.hot?.accept('/${relative(root, path)}', (...args) => __ILES_PAGE_UPD
 
     appConfig.jsx === 'preact' && {
       name: 'iles:preact-jsx-config',
-      config () {
+      config() {
         return { esbuild: { include: /\.(tsx?|jsx)$/ } }
       },
     },
@@ -252,7 +269,7 @@ import.meta.hot?.accept('/${relative(root, path)}', (...args) => __ILES_PAGE_UPD
 
 // Internal: Inspect the code definition for a Vue SFC to locate the place where
 // the SFC is defined, in order to inject additional data.
-function indexOfVueComponentDefinition (code: string) {
+function indexOfVueComponentDefinition(code: string) {
   let sfcConstIndex = code.indexOf('const _sfc_main = ')
 
   if (sfcConstIndex === -1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      parse5:
+        specifier: ^7.2.1
+        version: 7.2.1
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -5419,8 +5422,8 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
-  parse5@7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -11527,7 +11530,7 @@ snapshots:
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.0.2
-      parse5: 7.1.2
+      parse5: 7.2.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.2
@@ -13009,7 +13012,7 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
-  parse5@7.1.2:
+  parse5@7.2.1:
     dependencies:
       entities: 4.5.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@iconify-json/heroicons-outline':
         specifier: ^1.1.10
         version: 1.1.10
+      '@islands/excerpt':
+        specifier: workspace:*
+        version: link:../packages/excerpt
       '@islands/headings':
         specifier: workspace:*
         version: link:../packages/headings


### PR DESCRIPTION
This PR covers:

- docs: 📝 Moved app.ts docs section from config to development, config is now purely iles.config.ts related
- feat: ✨ Support user provider index.html, used parse5, docs updated
- docs: 📝 Added new section to getting started - Add iles to existing project
- docs: 📝 Added new Recipes set of pages, with the first recipe post
- docs: 📝 Override site wide MetaTags like ogImage etc for individual Recipes