### PR TITLE
Fix mdx plugin transforming virtual documents module paths ending with .mdx

### DIFF
--- a/packages/iles/tests/mdx.spec.ts
+++ b/packages/iles/tests/mdx.spec.ts
@@ -1,0 +1,40 @@
+import { test, describe, expect } from 'vite-plus/test'
+
+import IlesMdx from '@mdx/mdx-vite-plugins'
+
+describe('mdx plugin', () => {
+  test('should not transform virtual documents module ending with .mdx', async () => {
+    const plugins = IlesMdx()
+    const compilePlugin = plugins.find(p => p.name === 'iles:mdx:compile')!
+
+    // Simulate configResolved to initialize the processor
+    await (compilePlugin as any).configResolved({ mode: 'production', build: { sourcemap: false } })
+
+    const virtualDocId = '/@islands/documents?pattern=~/pages/posts/*.mdx'
+    const result = await (compilePlugin as any).transform('export default []', virtualDocId)
+    expect(result).toBeUndefined()
+  })
+
+  test('should not transform virtual documents module with .mdx in query', async () => {
+    const plugins = IlesMdx()
+    const sfcPlugin = plugins.find(p => p.name === 'iles:mdx:sfc')!
+
+    await (plugins[0] as any).configResolved({ mode: 'development', build: { sourcemap: false } })
+
+    const virtualDocId = '/@islands/documents?pattern=src/posts/hello.mdx'
+    const result = await (sfcPlugin as any).transform('export default []', virtualDocId)
+    expect(result).toBeUndefined()
+  })
+
+  test('should still transform actual .mdx files', async () => {
+    const plugins = IlesMdx()
+    const compilePlugin = plugins.find(p => p.name === 'iles:mdx:compile')!
+
+    await (compilePlugin as any).configResolved({ mode: 'production', build: { sourcemap: false } })
+
+    const mdxContent = '# Hello World'
+    const result = await (compilePlugin as any).transform(mdxContent, '/src/pages/post.mdx')
+    expect(result).toBeDefined()
+    expect(result.code).toBeDefined()
+  })
+})

--- a/packages/mdx/src/mdx-vite-plugins.ts
+++ b/packages/mdx/src/mdx-vite-plugins.ts
@@ -14,7 +14,7 @@ export default function IlesMdx (options: MarkdownOptions = {}): Plugin[] {
   let isDevelopment: boolean
 
   function shouldTransform (path: string) {
-    return markdownProcessor.extnames.includes(extname(path))
+    return markdownProcessor.extnames.includes(extname(path.split('?', 2)[0]))
   }
 
   async function createMdxProcessor (sourcemap: string | boolean) {

--- a/packages/mdx/src/mdx-vite-plugins.ts
+++ b/packages/mdx/src/mdx-vite-plugins.ts
@@ -13,8 +13,12 @@ export default function IlesMdx (options: MarkdownOptions = {}): Plugin[] {
   let markdownProcessor: ReturnType<typeof createFormatAwareProcessors>
   let isDevelopment: boolean
 
+  function stripQueryParams (path: string) {
+    return path.split('?', 2)[0]
+  }
+
   function shouldTransform (path: string) {
-    return markdownProcessor.extnames.includes(extname(path.split('?', 2)[0]))
+    return markdownProcessor.extnames.includes(extname(stripQueryParams(path)))
   }
 
   async function createMdxProcessor (sourcemap: string | boolean) {


### PR DESCRIPTION
The shouldTransform check used extname(path) which matched .mdx in query
strings like /@islands/documents?pattern=~/pages/posts/*.mdx. Strip query
parameters before checking the extension.

https://claude.ai/code/session_01JtF19Q3j4iAhG5uobdTQCU