### PR TITLE
refactor: use rolldown inject config for composable auto-imports during build

### DIFF
--- a/packages/iles/src/node/plugin/composables.ts
+++ b/packages/iles/src/node/plugin/composables.ts
@@ -14,6 +14,10 @@ const composables = [
   'useRoute',
 ]
 
+export const composablesInjectConfig: Record<string, [string, string]> = Object.fromEntries(
+  composables.map(name => [name, ['iles', name]]),
+)
+
 export async function autoImportComposables (code: string, id: string): Promise<string | undefined> {
   const matches = Array.from(code.matchAll(composableUsageRegex))
   if (matches.length === 0) return

--- a/packages/iles/src/node/plugin/plugin.ts
+++ b/packages/iles/src/node/plugin/plugin.ts
@@ -14,7 +14,7 @@ import { parseId } from './parse'
 import { wrapIslandsInSFC, wrapLayout } from './wrap'
 import { extendSite } from './site'
 import { detectMDXComponents } from './markdown'
-import { autoImportComposables, writeComposablesDTS } from './composables'
+import { autoImportComposables, composablesInjectConfig, writeComposablesDTS } from './composables'
 import documents from './documents'
 
 function isMarkdown (path: string) {
@@ -159,7 +159,17 @@ export default function IslandsPlugins (appConfig: AppConfig): PluginOption[] {
     {
       name: 'iles:composables',
       enforce: 'post',
+      config () {
+        return {
+          build: {
+            rolldownOptions: {
+              transform: { inject: composablesInjectConfig },
+            },
+          },
+        }
+      },
       async transform (code, id) {
+        if (isBuild) return
         if (!id.startsWith(appConfig.srcDir)) return
 
         const { path, query } = parseId(id)


### PR DESCRIPTION
Replace the iles:composables transform plugin with Vite's
build.rolldownOptions.transform.inject config option for builds, falling
back to the existing transform-based auto-import for dev mode where the
rolldown inject option is not available.

https://claude.ai/code/session_01NZyaWN67FYx9xFUQP6nEFG